### PR TITLE
fix: Need distrobox label for prompt

### DIFF
--- a/quadlets/bluefin-cli/bluefin-cli-distrobox-quadlet.container
+++ b/quadlets/bluefin-cli/bluefin-cli-distrobox-quadlet.container
@@ -19,6 +19,7 @@ PodmanArgs=--entrypoint /usr/bin/entrypoint
 PodmanArgs=--ipc host
 PodmanArgs=--no-hosts
 PodmanArgs=--privileged
+PodmanArgs=--label manager=distrobox
 PodmanArgs=--security-opt label=disable
 PodmanArgs=--security-opt apparmor=unconfined
 Ulimit=host

--- a/quadlets/wolfi-toolbox/wolfi-distrobox-quadlet.container
+++ b/quadlets/wolfi-toolbox/wolfi-distrobox-quadlet.container
@@ -19,6 +19,7 @@ PodmanArgs=--entrypoint /usr/bin/entrypoint
 PodmanArgs=--ipc host
 PodmanArgs=--no-hosts
 PodmanArgs=--privileged
+PodmanArgs=--label manager=distrobox
 PodmanArgs=--security-opt label=disable
 PodmanArgs=--security-opt apparmor=unconfined
 Ulimit=host

--- a/toolboxes/bluefin-cli/Containerfile.bluefin-cli
+++ b/toolboxes/bluefin-cli/Containerfile.bluefin-cli
@@ -1,6 +1,7 @@
 FROM ghcr.io/ublue-os/wolfi-toolbox
 
-LABEL usage="This image is meant to be used with the Toolbox or Distrobox commands" \
+LABEL com.github.containers.toolbox="true" \
+      usage="This image is meant to be used with the Toolbox or Distrobox commands" \
       summary="A new cloud-native terminal experience powered by Wolfi and Homebrew" \
       maintainer="jorge.castro@gmail.com"
 

--- a/toolboxes/wolfi-toolbox/Containerfile.wolfi
+++ b/toolboxes/wolfi-toolbox/Containerfile.wolfi
@@ -1,7 +1,8 @@
 FROM cgr.dev/chainguard/wolfi-base
 # Thanks to Nuno do Carmo for the initial prototype
 
-LABEL usage="This image is meant to be used with the Toolbox or Distrobox command" \
+LABEL com.github.containers.toolbox="true" \
+      usage="This image is meant to be used with the Toolbox or Distrobox command" \
       summary="A blank Wolfi distrobox, suitable for development" \
       maintainer="jorge.castro@gmail.com"
 


### PR DESCRIPTION
TODO: Find a way to not have systemd managed containers be seen by toolbox/distrobox while still letting prompt work.