### PR TITLE
chore: libcap version pin no longer required.

### DIFF
--- a/toolboxes/wolfi-toolbox/packages.wolfi
+++ b/toolboxes/wolfi-toolbox/packages.wolfi
@@ -11,7 +11,7 @@ gpg
 iproute2
 iputils
 keyutils
-libcap=2.68-r0
+libcap
 libsm
 libx11
 libxau


### PR DESCRIPTION
Refs
https://github.com/ublue-os/toolboxes/commit/7cd04424d72bac1200d1d6721e97f86c28a3adc6
https://github.com/ublue-os/bluefin/pull/812