### PR TITLE
feat: Add Wolfi development variants of Bluefin CLI and Wolfi Toolbox

### DIFF
--- a/.github/workflows/build-bluefin-toolbox.yml
+++ b/.github/workflows/build-bluefin-toolbox.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ["latest", "latest-dev"]
+        tag: ["latest", "testing"]
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action

--- a/.github/workflows/build-bluefin-toolbox.yml
+++ b/.github/workflows/build-bluefin-toolbox.yml
@@ -6,8 +6,8 @@ on:
   merge_group:
   workflow_dispatch:
 env:
+    SOURCE_IMAGE_NAME: wolfi-toolbox
     IMAGE_NAME: bluefin-cli
-    IMAGE_TAGS: latest
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 concurrency:
@@ -24,6 +24,8 @@ jobs:
       id-token: write
     strategy:
       fail-fast: false
+      matrix:
+        tag: ["latest", "latest-dev"]
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
@@ -32,10 +34,7 @@ jobs:
       - name: Verify base container
         uses: EyeCantCU/cosign-action/verify@v0.2.2
         with:
-          containers: wolfi-base
-          cert-identity: https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
-          oidc-issuer: https://token.actions.githubusercontent.com
-          registry: cgr.dev/chainguard
+          containers: ${{ env.SOURCE_IMAGE_NAME}}:${{ matrix.tag }}
 
       # Build metadata
       - name: Image Metadata
@@ -55,10 +54,14 @@ jobs:
           containerfiles: |
             ./toolboxes/bluefin-cli/Containerfile.bluefin-cli
           image: ${{ env.IMAGE_NAME }}
-          tags: ${{ env.IMAGE_TAGS }}
+          tags: ${{ matrix.tag }}
+          build-args: |
+            SOURCE_IMAGE_NAME=${{ env.SOURCE_IMAGE_NAME }}
+            SOURCE_IMAGE_REGISTRY=${{ env.IMAGE_REGISTRY }}
+            IMAGE_TAG=${{ matrix.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           oci: false
-          
+
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12
       - name: Lowercase Registry
@@ -81,7 +84,7 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-            
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
@@ -89,7 +92,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-            
+
       # Sign container
       - uses: sigstore/cosign-installer@v3.3.0
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build-wolfi-toolbox.yml
+++ b/.github/workflows/build-wolfi-toolbox.yml
@@ -9,6 +9,7 @@ env:
     IMAGE_NAME: wolfi-toolbox
     IMAGE_TAGS: latest
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+    SOURCE_IMAGE_REGISTRY: cgr.dev/chainguard
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -24,15 +25,25 @@ jobs:
       id-token: write
     strategy:
       fail-fast: false
+      matrix:
+        tag: ["latest", "latest-dev"]
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
         uses: actions/checkout@v4
 
+      - name: Determine base container
+        run: |
+          if [[ "${{ matrix.tag }}" == "latest" ]]; then
+            echo "SOURCE_IMAGE_NAME=wolfi-base" >> $GITHUB_ENV
+          elif [[ "${{ matrix.tag }}" == "latest-dev" ]]; then
+            echo "SOURCE_IMAGE_NAME=sdk" >> $GITHUB_ENV
+          fi
+
       - name: Verify base container
         uses: EyeCantCU/cosign-action/verify@v0.2.2
         with:
-          containers: wolfi-base
+          containers: ${{ env.SOURCE_IMAGE_NAME }}
           cert-identity: https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
           oidc-issuer: https://token.actions.githubusercontent.com
           registry: cgr.dev/chainguard
@@ -55,10 +66,13 @@ jobs:
           containerfiles: |
             ./toolboxes/wolfi-toolbox/Containerfile.wolfi
           image: ${{ env.IMAGE_NAME }}
-          tags: ${{ env.IMAGE_TAGS }}
+          tags: ${{ matrix.tag }}
+          build-args: |
+            SOURCE_IMAGE_NAME: ${{ env.SOURCE_IMAGE_NAME }}
+            SOURCE_IMAGE_REGISTRY: ${{ env.SOURCE_IMAGE_REGISTRY }}
           labels: ${{ steps.meta.outputs.labels }}
           oci: false
-          
+
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12
       - name: Lowercase Registry
@@ -81,7 +95,7 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-            
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
@@ -89,7 +103,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-            
+
       # Sign container
       - uses: sigstore/cosign-installer@v3.3.0
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build-wolfi-toolbox.yml
+++ b/.github/workflows/build-wolfi-toolbox.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ["latest", "latest-dev"]
+        tag: ["latest", "testing"]
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The [WolfiOS](https://edu.chainguard.dev/open-source/wolfi/overview/) apk packag
 
 The intended endstate of `bluefin-cli` is a fully automated declarative config managed via git using Wolfi packages for clean rebuilds daily. `brew` is used to fill out the "long tail" of existing software.
 
-Both `bluefin-cli` and `wolfi-toolbox` have Wolfi developer variants built from the Wolfi SDK image, intended for Wolfi package and image development. They include utilities such as melange, wolfictl, and apko. These are pushed to the `latest-dev` tag.
+Both `bluefin-cli` and `wolfi-toolbox` have Wolfi developer variants built from the Wolfi SDK image, intended for Wolfi package and image development. They include utilities such as melange, wolfictl, and apko. These are pushed to the `testing` tag.
 
 # Stats
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The [WolfiOS](https://edu.chainguard.dev/open-source/wolfi/overview/) apk packag
 
 The intended endstate of `bluefin-cli` is a fully automated declarative config managed via git using Wolfi packages for clean rebuilds daily. `brew` is used to fill out the "long tail" of existing software.
 
+Both `bluefin-cli` and `wolfi-toolbox` have Wolfi developer variants built from the Wolfi SDK image, intended for Wolfi package and image development. They include utilities such as melange, wolfictl, and apko. These are pushed to the `latest-dev` tag.
+
 # Stats
 
 ## Star History

--- a/toolboxes/bluefin-cli/Containerfile.bluefin-cli
+++ b/toolboxes/bluefin-cli/Containerfile.bluefin-cli
@@ -1,4 +1,10 @@
-FROM ghcr.io/ublue-os/wolfi-toolbox
+ARG SOURCE_IMAGE_NAME="${SOURCE_IMAGE_NAME:-wolfi-toolbox}"
+ARG SOURCE_IMAGE_REGISTRY="${SOURCE_IMAGE_REGISTRY:-ghcr.io/ublue-os}"
+ARG SOURCE_IMAGE="${SOURCE_IMAGE_REGISTRY}/${SOURCE_IMAGE_NAME}"
+
+ARG IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+FROM $SOURCE_IMAGE:$IMAGE_TAG
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the Toolbox or Distrobox commands" \

--- a/toolboxes/wolfi-toolbox/Containerfile.wolfi
+++ b/toolboxes/wolfi-toolbox/Containerfile.wolfi
@@ -1,4 +1,8 @@
-FROM cgr.dev/chainguard/wolfi-base
+ARG SOURCE_IMAGE_NAME="${SOURCE_IMAGE_NAME:-wolfi-base}"
+ARG SOURCE_IMAGE_REGISTRY="${SOURCE_IMAGE_REGISTRY:-cgr.dev/chainguard}"
+ARG SOURCE_IMAGE="${SOURCE_IMAGE_REGISTRY}/${SOURCE_IMAGE_NAME}"
+
+FROM $SOURCE_IMAGE:latest
 # Thanks to Nuno do Carmo for the initial prototype
 
 LABEL com.github.containers.toolbox="true" \


### PR DESCRIPTION
This introduces a Wolfi development variant of both Bluefin CLI and Wolfi Toolbox images, built from the Wolfi SDK image. These variants use the 'testing' tag and include tools such as melange, apko, and wolfictl for Wolfi package and image development.