### PR TITLE
chore(wolfi): Create dx variants of Bluefin CLI and Wolfi Toolbox

### DIFF
--- a/.github/workflows/build-bluefin-toolbox.yml
+++ b/.github/workflows/build-bluefin-toolbox.yml
@@ -6,9 +6,8 @@ on:
   merge_group:
   workflow_dispatch:
 env:
-    SOURCE_IMAGE_NAME: wolfi-toolbox
-    IMAGE_NAME: bluefin-cli
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+    IMAGE_TAGS: latest
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -25,16 +24,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ["latest", "testing"]
+        image_name: ["bluefin-cli", "bluefin-cli-dx"]
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
         uses: actions/checkout@v4
 
-      - name: Verify base container
+      - name: Determine base image
+        run: |
+          if [[ "${{ matrix.image_name }}" == "bluefin-cli" ]]; then
+            echo "SOURCE_IMAGE_NAME=wolfi-toolbox" >> $GITHUB_ENV
+          elif [[ "${{ matrix.image_name }}" == "bluefin-dx-cli" ]]; then
+            echo "SOURCE_IMAGE_NAME=wolfi-dx-toolbox" >> $GITHUB_ENV
+          fi
+
+      - name: Verify base image
         uses: EyeCantCU/cosign-action/verify@v0.2.2
         with:
-          containers: ${{ env.SOURCE_IMAGE_NAME}}:${{ matrix.tag }}
+          containers: ${{ env.SOURCE_IMAGE_NAME }}
 
       # Build metadata
       - name: Image Metadata
@@ -42,7 +49,7 @@ jobs:
         id: meta
         with:
           images: |
-            ${{ env.IMAGE_NAME }}
+            ${{ matrix.image_name }}
           labels: |
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/boxkit/main/README.md
 
@@ -53,12 +60,11 @@ jobs:
         with:
           containerfiles: |
             ./toolboxes/bluefin-cli/Containerfile.bluefin-cli
-          image: ${{ env.IMAGE_NAME }}
-          tags: ${{ matrix.tag }}
+          image: ${{ matrix.image_name }}
+          tags: ${{ env.IMAGE_TAGS }}
           build-args: |
             SOURCE_IMAGE_NAME=${{ env.SOURCE_IMAGE_NAME }}
             SOURCE_IMAGE_REGISTRY=${{ env.IMAGE_REGISTRY }}
-            IMAGE_TAG=${{ matrix.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           oci: false
 
@@ -102,7 +108,7 @@ jobs:
         run: |
           echo "${{ env.COSIGN_PRIVATE_KEY }}" > cosign.key
           wc -c cosign.key
-          cosign sign -y --key cosign.key ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
+          cosign sign -y --key cosign.key ${{ steps.registry_case.outputs.lowercase }}/${{ matrix.image_name }}@${TAGS}
         env:
           TAGS: ${{ steps.push.outputs.digest }}
           COSIGN_EXPERIMENTAL: false

--- a/.github/workflows/build-wolfi-toolbox.yml
+++ b/.github/workflows/build-wolfi-toolbox.yml
@@ -6,7 +6,6 @@ on:
   merge_group:
   workflow_dispatch:
 env:
-    IMAGE_NAME: wolfi-toolbox
     IMAGE_TAGS: latest
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
     SOURCE_IMAGE_REGISTRY: cgr.dev/chainguard
@@ -26,21 +25,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ["latest", "testing"]
+        image_name: ["wolfi-toolbox", "wolfi-dx-toolbox"]
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
         uses: actions/checkout@v4
 
-      - name: Determine base container
+      - name: Determine base image
         run: |
-          if [[ "${{ matrix.tag }}" == "latest" ]]; then
+          if [[ "${{ matrix.image_name }}" == "wolfi-toolbox" ]]; then
             echo "SOURCE_IMAGE_NAME=wolfi-base" >> $GITHUB_ENV
-          elif [[ "${{ matrix.tag }}" == "latest-dev" ]]; then
+          elif [[ "${{ matrix.image_name }}" == "wolfi-dx-toolbox" ]]; then
             echo "SOURCE_IMAGE_NAME=sdk" >> $GITHUB_ENV
           fi
 
-      - name: Verify base container
+      - name: Verify base image
         uses: EyeCantCU/cosign-action/verify@v0.2.2
         with:
           containers: ${{ env.SOURCE_IMAGE_NAME }}
@@ -54,7 +53,7 @@ jobs:
         id: meta
         with:
           images: |
-            ${{ env.IMAGE_NAME }}
+            ${{ matrix.image_name }}
           labels: |
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/boxkit/main/README.md
 
@@ -65,8 +64,8 @@ jobs:
         with:
           containerfiles: |
             ./toolboxes/wolfi-toolbox/Containerfile.wolfi
-          image: ${{ env.IMAGE_NAME }}
-          tags: ${{ matrix.tag }}
+          image: ${{ matrix.image_name }}
+          tags: ${{ env.IMAGE_TAGS }}
           build-args: |
             SOURCE_IMAGE_NAME: ${{ env.SOURCE_IMAGE_NAME }}
             SOURCE_IMAGE_REGISTRY: ${{ env.SOURCE_IMAGE_REGISTRY }}
@@ -113,7 +112,7 @@ jobs:
         run: |
           echo "${{ env.COSIGN_PRIVATE_KEY }}" > cosign.key
           wc -c cosign.key
-          cosign sign -y --key cosign.key ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
+          cosign sign -y --key cosign.key ${{ steps.registry_case.outputs.lowercase }}/${{ matrix.image_name }}@${TAGS}
         env:
           TAGS: ${{ steps.push.outputs.digest }}
           COSIGN_EXPERIMENTAL: false

--- a/toolboxes/bluefin-cli/Containerfile.bluefin-cli
+++ b/toolboxes/bluefin-cli/Containerfile.bluefin-cli
@@ -2,9 +2,7 @@ ARG SOURCE_IMAGE_NAME="${SOURCE_IMAGE_NAME:-wolfi-toolbox}"
 ARG SOURCE_IMAGE_REGISTRY="${SOURCE_IMAGE_REGISTRY:-ghcr.io/ublue-os}"
 ARG SOURCE_IMAGE="${SOURCE_IMAGE_REGISTRY}/${SOURCE_IMAGE_NAME}"
 
-ARG IMAGE_TAG="${IMAGE_TAG:-latest}"
-
-FROM $SOURCE_IMAGE:$IMAGE_TAG
+FROM $SOURCE_IMAGE:latest
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the Toolbox or Distrobox commands" \


### PR DESCRIPTION
Drop the testing tag, and rename the Wolfi SDK based images as dx images to reflect that they're utilized by Ublue developers