### PR TITLE
fix: Patch distrobox-init for no-internet

### DIFF
--- a/toolboxes/bluefin-cli/Containerfile.bluefin-cli
+++ b/toolboxes/bluefin-cli/Containerfile.bluefin-cli
@@ -19,5 +19,10 @@ RUN apk update && \
     mv /home/linuxbrew /home/homebrew && \
     rm /toolbox-packages
 
+# Patch /usr/bin/entrypoint
+RUN sed -i '349,489 s/^/#/' /usr/bin/entrypoint && \
+    sed -i '499,1355 s/^/#/' /usr/bin/entrypoint && \
+    sed -i '1357 s/^/#/' /usr/bin/entrypoint
+
 # Change root shell to BASH
 RUN sed -i -e '/^root/s/\/bin\/ash/\/bin\/bash/' /etc/passwd

--- a/toolboxes/bluefin-cli/packages.bluefin-cli
+++ b/toolboxes/bluefin-cli/packages.bluefin-cli
@@ -1,5 +1,6 @@
 atuin
 brew
 eza
+sed
 starship
 sudo-rs


### PR DESCRIPTION
@castrojo noticed that when using a quadlet, if there is no internet at startup the container cannot run. This comments out all of the package checks which requires internet.

This removes the ability to add additional_packages into the Exec= line of `bluefin-cli.container` to have them installed at startup.