### PR TITLE
fix(wolfi): Remove local repository reference

### DIFF
--- a/toolboxes/wolfi-toolbox/Containerfile.wolfi
+++ b/toolboxes/wolfi-toolbox/Containerfile.wolfi
@@ -12,8 +12,9 @@ LABEL com.github.containers.toolbox="true" \
 
 COPY ./toolboxes/wolfi-toolbox/packages.wolfi /toolbox-packages
 
-# Update image
-RUN apk update && \
+# Remove local repository and update image
+RUN sed -i 's/@local.*//g' /etc/apk/repositories \
+    apk update && \
     apk upgrade
 
 # Add optional packages


### PR DESCRIPTION
This is used when building packages locally so that they can be more easily installed. While helpful for quickly installing built packages, this gets hardcoded to the GitHub workspace directory and half the time an explicit installation path ends up being used anyway