### PR TITLE
fix(wolfi-dx-toolbox): Swap libcurl4 with libcurl-openssl4

### DIFF
--- a/toolboxes/wolfi-toolbox/packages.wolfi-dx
+++ b/toolboxes/wolfi-toolbox/packages.wolfi-dx
@@ -17,7 +17,7 @@ isl
 libbrotlicommon1
 libbrotlidec1
 libcrypto3
-libcurl4
+libcurl-openssl4
 libgcc
 libnghttp2-14
 libpcre2-32-0


### PR DESCRIPTION
This package doesn't align with the SDK and borks curl. On closer analysis, the correct package is `libcurl-openssl4`