### PR TITLE
feat(wolfi-dx-toolbox): Install latest utilities, match melange SDK a…

### DIFF
--- a/.github/workflows/build-wolfi-toolbox.yml
+++ b/.github/workflows/build-wolfi-toolbox.yml
@@ -48,6 +48,11 @@ jobs:
           labels: |
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/boxkit/main/README.md
 
+      # Maximize build space for DX
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@v6
+        if: matrix.image_name == 'wolfi-dx-toolbox'
+
       # Build image using Buildah action
       - name: Build Image
         id: build_image

--- a/toolboxes/wolfi-toolbox/Containerfile.wolfi
+++ b/toolboxes/wolfi-toolbox/Containerfile.wolfi
@@ -22,6 +22,32 @@ RUN grep -v '^#' /tmp/packages.wolfi | xargs apk add && \
         grep -v '^#' /tmp/packages.wolfi-dx | xargs apk add \
     ; fi
 
+# DX: Include utilities available in the melange SDK
+RUN if [[ "${IMAGE_NAME}" =~ "dx" ]]; then \
+        cd /tmp && \
+        export PATH="/tmp/go/bin:${PATH}" && \
+        # go setup
+        export GOPATH="/tmp/go" && \
+        mkdir -p "${GOPATH}" && \
+        # goimports
+        go install golang.org/x/tools/cmd/goimports@latest && \
+        mkdir -p "/usr/bin" && \
+        mv "${GOPATH}/bin/goimports" "/usr/bin" && \
+        # melange
+        git clone https://github.com/chainguard-dev/melange.git && \
+        (cd melange && make melange install) && \
+        # apko
+        git clone https://github.com/chainguard-dev/apko.git && \
+        (cd apko && make apko install) && \
+        # wolfictl
+        git clone https://github.com/wolfi-dev/wolfictl.git && \
+        (cd wolfictl && make wolfictl install) && \
+        # yam
+        git clone https://github.com/chainguard-dev/yam.git && \
+        cd yam && \
+        go build -v -o "/usr/bin/yam" . \
+    ; fi
+
 # Get Distrobox-host-exec and host-spawn
 RUN git clone https://github.com/89luca89/distrobox.git --single-branch /tmp/distrobox && \
     cp /tmp/distrobox/distrobox-host-exec /usr/bin/distrobox-host-exec && \


### PR DESCRIPTION
…dditions

After switching from the Wolfi SDK to the base image, we lost the latest versions of a few utilities in the process. This corrects that

This ships the latest versions of melange, apko, goimports, wolfictl, and yam