### PR TITLE
fix: remove unused flags from distrobox exec line.

### DIFF
--- a/quadlets/bluefin-cli/bluefin-cli.container
+++ b/quadlets/bluefin-cli/bluefin-cli.container
@@ -8,7 +8,7 @@ ContainerName=bluefin
 Environment=SHELL=%s
 Environment=HOME=%h
 Environment=container=podman
-Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" --pre-init-hooks " " --additional-packages " " -- " "
+Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" -- " "
 Image=ghcr.io/ublue-os/bluefin-cli:latest
 HostName=bluefin.%l
 Label=manager=distrobox

--- a/quadlets/bluefin-cli/bluefin-dx-cli.container
+++ b/quadlets/bluefin-cli/bluefin-dx-cli.container
@@ -8,7 +8,7 @@ ContainerName=bluefin
 Environment=SHELL=%s
 Environment=HOME=%h
 Environment=container=podman
-Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" --pre-init-hooks " " --additional-packages " " -- " "
+Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" -- " "
 Image=ghcr.io/ublue-os/bluefin-dx-cli:latest
 HostName=bluefin-dx.%l
 Label=manager=distrobox

--- a/quadlets/fedora-toolbox/fedora-distrobox-quadlet.container
+++ b/quadlets/fedora-toolbox/fedora-distrobox-quadlet.container
@@ -8,7 +8,7 @@ ContainerName=fedora-distrobox-quadlet
 Environment=SHELL=%s
 Environment=HOME=%h
 Environment=container=podman
-Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" --pre-init-hooks " " --additional-packages " " -- " "
+Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" -- " "
 Image=ghcr.io/ublue-os/fedora-toolbox:latest
 HostName=fedora-toolbox.%l
 Label=manager=distrobox

--- a/quadlets/ubuntu-toolbox/ubuntu-distrobox-quadlet.container
+++ b/quadlets/ubuntu-toolbox/ubuntu-distrobox-quadlet.container
@@ -8,7 +8,7 @@ ContainerName=ubuntu-distrobox-quadlet
 Environment=SHELL=%s
 Environment=HOME=%h
 Environment=container=podman
-Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" --pre-init-hooks " " --additional-packages " " -- " "
+Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" -- " "
 Image=ghcr.io/ublue-os/ubuntu-toolbox:latest
 HostName=ubuntu-toolbox.%l
 Label=manager=distrobox

--- a/quadlets/wolfi-toolbox/wolfi-distrobox-quadlet.container
+++ b/quadlets/wolfi-toolbox/wolfi-distrobox-quadlet.container
@@ -8,7 +8,7 @@ ContainerName=wolfi-quadlet
 Environment=SHELL=%s
 Environment=HOME=%h
 Environment=container=podman
-Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" --pre-init-hooks " " --additional-packages " " -- " "
+Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" -- " "
 Image=ghcr.io/ublue-os/wolfi-toolbox:latest
 HostName=wolfi-quadlet.%l
 Label=manager=distrobox

--- a/quadlets/wolfi-toolbox/wolfi-dx-distrobox-quadlet.container
+++ b/quadlets/wolfi-toolbox/wolfi-dx-distrobox-quadlet.container
@@ -8,7 +8,7 @@ ContainerName=wolfi-quadlet
 Environment=SHELL=%s
 Environment=HOME=%h
 Environment=container=podman
-Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" --pre-init-hooks " " --additional-packages " " -- " "
+Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" -- " "
 Image=ghcr.io/ublue-os/wolfi-dx-toolbox:latest
 HostName=wolfi-quadlet.%l
 Label=manager=distrobox

--- a/toolboxes/bluefin-cli/Containerfile.bluefin-cli
+++ b/toolboxes/bluefin-cli/Containerfile.bluefin-cli
@@ -19,10 +19,6 @@ RUN apk update && \
     mv /home/linuxbrew /home/homebrew && \
     rm /toolbox-packages
 
-# Patch /usr/bin/entrypoint
-RUN sed -i '/missing_packages=0/,/# Set SHELL to the install path inside the container/ s/^/#/' /usr/bin/entrypoint && \
-    sed -i '/# Set SHELL to the install path inside the container/a touch /.containersetupdone' /usr/bin/entrypoint
-
 # Use and configure bash, retrieve bash-prexec
 RUN curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o /tmp/bash-prexec && \
     mkdir -p /usr/share/ && \

--- a/toolboxes/wolfi-toolbox/Containerfile.wolfi
+++ b/toolboxes/wolfi-toolbox/Containerfile.wolfi
@@ -10,7 +10,7 @@ ARG IMAGE_NAME="${IMAGE_NAME:-wolfi-toolbox}"
 
 COPY ./toolboxes/wolfi-toolbox/packages.wolfi \
      ./toolboxes/wolfi-toolbox/packages.wolfi-dx \
-     /tmp
+     /tmp/
 
 # Update image
 RUN apk update && \


### PR DESCRIPTION
This will make is so we don't cause the distrobox containers to need internet to start.
This also means we can remove the patch we did to bluefin-cli distrobox-init