### PR TITLE
fix: patch distrobox-init for startup without internet

### DIFF
--- a/toolboxes/bluefin-cli/Containerfile.bluefin-cli
+++ b/toolboxes/bluefin-cli/Containerfile.bluefin-cli
@@ -19,6 +19,9 @@ RUN apk update && \
     mv /home/linuxbrew /home/homebrew && \
     rm /toolbox-packages
 
+# Patch /usr/bin/entrypoint
+RUN sed -i '/for dep in ${dependencies}/i dependencies=""' /usr/bin/entrypoint 
+
 # Use and configure bash, retrieve bash-prexec
 RUN curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o /tmp/bash-prexec && \
     mkdir -p /usr/share/ && \


### PR DESCRIPTION
https://github.com/ublue-os/toolboxes/pull/74, which was introduced to resolve https://github.com/ublue-os/toolboxes/issues/73 broke the ability to start `bluefin-cli` without internet. 

The `bluefin-cli` image does not have the packages `man` and `pinentry`, which is listed as a dependency for every distrobox container in `distrobox-init` (see [here](https://github.com/89luca89/distrobox/blob/867f4f85c762bc74bf398c8654984b801138e154/distrobox-init#L366)). This causes all packages to be reinstalled when the container is started, which requires internet. Hence, if there is no internet, the container fails to start.

This pull request patches  `distrobox-init` to make the dependency list empty. An alternative fix would be to include all the dependencies listed by  `distrobox-init` in the `bluefin-cli` image.