### PR TITLE
fix: add missing distrobox package `man`

### DIFF
--- a/toolboxes/wolfi-toolbox/packages.wolfi
+++ b/toolboxes/wolfi-toolbox/packages.wolfi
@@ -22,6 +22,7 @@ libice
 libxmu
 libxt
 linux-pam
+man-db
 mount
 ncurses
 ncurses-terminfo


### PR DESCRIPTION
Fix https://github.com/ublue-os/toolboxes/issues/77