### PR TITLE
feat: bump ubuntu toolbox to 24.04

### DIFF
--- a/toolboxes/ubuntu-toolbox/Containerfile.ubuntu
+++ b/toolboxes/ubuntu-toolbox/Containerfile.ubuntu
@@ -1,5 +1,5 @@
-FROM quay.io/toolbx-images/ubuntu-toolbox:22.04
-# From https://github.com/toolbx-images/images/tree/main/ubuntu/22.04
+FROM quay.io/toolbx-images/ubuntu-toolbox:24.04
+# From https://github.com/toolbx-images/images/tree/main/ubuntu/24.04
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \


### PR DESCRIPTION
This is for when Containers/toolboxes starts building 24.04

Images already exist upstream if we wish to build from there.