### PR TITLE
feat: powershell toolbox improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Centralized repository of containers designed for Toolbox/Distrobox with batteri
 - `fedora-toolbox` - a Fedora base image
 - `wolfi-toolbox` - a WolfiOS base image
 - `bluefin-cli` - a WolfiOS based image with Homebrew and a strongly opinionated default experience
-- `powershell-toolbox` - a WolfiOS based image with PowerShell and other Microsoft related tooling 
+- `powershell-toolbox` - a WolfiOS based image with PowerShell and other Microsoft related tooling
 
 It is strongly recommended that the [Ptyxis terminal](https://gitlab.gnome.org/chergert/ptyxis) be used with these toolboxes and is the default experience in both [Bazzite](https://bazzite.gg) and [Bluefin](https://projectbluefin.io).
 
@@ -23,7 +23,7 @@ It is strongly recommended that the [Ptyxis terminal](https://gitlab.gnome.org/c
 
 Podman supports starting containers via a systemd generator. Quadlets replaced the `podman generate systemd` command and provide a method to create a systemd service for managing your container. The generated unit file can automatically start your container on login, automatically check for updates from the registry, and automatically clean-up the container and any transient volumes when the container stops. This provides an ideal way to have a clean slate on each login.
 
-Inside the quadlets directory are example quadlets each of the toolboxes listed above. Distrobox and Toolbox provide a convenient way to integrate the containers into your host.`ubuntu-toolbox` and `fedora-toolbox` can use either toolbox or distrobox. `wolfi-toolbox`, `bluefin-cli` and `powershell-toolbox` (WolfiOS base) are currently only compatible with distrobox. 
+Inside the quadlets directory are example quadlets each of the toolboxes listed above. Distrobox and Toolbox provide a convenient way to integrate the containers into your host.`ubuntu-toolbox` and `fedora-toolbox` can use either toolbox or distrobox. `wolfi-toolbox`, `bluefin-cli` and `powershell-toolbox` (WolfiOS base) are currently only compatible with distrobox.
 
 The quadlets mimic the create and enter commands to setup the container. You can use these by copying them to `~/.config/containers/systemd`. When using the Prompt terminal, they will appear in the menu as available containers. The `Exec=` line of the distrobox quadlets can be modified to include additional packages.
 
@@ -39,15 +39,15 @@ To utilize these, place the user service file in `~/.config/systemd/user` and ma
 
 ### Bluefin-CLI
 
-`bluefin-cli` is built from `wolfi-toolbox`. It contains [Homebrew](https://brew.sh/) configured out of the box. The brew state is bind mounted to a directory from your `$HOME`. Unlike the other toolboxes, `bluefin-cli` is intended for CLI applications _only_. 
+`bluefin-cli` is built from `wolfi-toolbox`. It contains [Homebrew](https://brew.sh/) configured out of the box. The brew state is bind mounted to a directory from your `$HOME`. Unlike the other toolboxes, `bluefin-cli` is intended for CLI applications _only_.
 
-Its primary purpose is to be **the** command line companion to Flathub-enabled systems by providing access to one of the largest command line repositories in the world via homebrew. Developer dependencies should be managed seperately via [devcontainers](https://github.com/devcontainers).  
+Its primary purpose is to be **the** command line companion to Flathub-enabled systems by providing access to one of the largest command line repositories in the world via homebrew. Developer dependencies should be managed seperately via [devcontainers](https://github.com/devcontainers).
 
 The default configuration destroys and updates this container daily so that the toolbox is built from scratch.
 
-Updates to brew itself happen automatically when the container rebuilds. Brew will automatically upgrade packages as you use it. Brew's state is also volume mounted to a file in your home directory so your container is fresh but your packages remain untouched. At this time it is **strongly recommended** to maintain a backup of your brew package list via the [brew bundle](https://docs.brew.sh/Manpage#bundle-subcommand) subcommand.  
+Updates to brew itself happen automatically when the container rebuilds. Brew will automatically upgrade packages as you use it. Brew's state is also volume mounted to a file in your home directory so your container is fresh but your packages remain untouched. At this time it is **strongly recommended** to maintain a backup of your brew package list via the [brew bundle](https://docs.brew.sh/Manpage#bundle-subcommand) subcommand.
 
-The [WolfiOS](https://edu.chainguard.dev/open-source/wolfi/overview/) apk package manager is preferred for fully declarative setups with [boxkit](https://github.com/ublue-os/boxkit). You can file package requests on the [WolfiOS repository](https://github.com/wolfi-dev/) for packages that you may need. We are working on a way to do this locally as well. 
+The [WolfiOS](https://edu.chainguard.dev/open-source/wolfi/overview/) apk package manager is preferred for fully declarative setups with [boxkit](https://github.com/ublue-os/boxkit). You can file package requests on the [WolfiOS repository](https://github.com/wolfi-dev/) for packages that you may need. We are working on a way to do this locally as well.
 
 The intended endstate of `bluefin-cli` is a fully automated declarative config managed via git using Wolfi packages for clean rebuilds daily. `brew` is used to fill out the "long tail" of existing software.
 
@@ -55,7 +55,7 @@ Both `bluefin-cli` and `wolfi-toolbox` have Wolfi developer variants built from 
 
 ### PowerShell-Toolbox
 
-`powershell-toolbox` is based on `WolfiOS`. Its primary purpose is to be a dedicated container for Microsoft related technologies used during development. It contains [PowerShell](https://github.com/PowerShell/PowerShell), [Azure CLI](https://github.com/Azure/azure-cli) and [.NET](https://github.com/dotnet/core) (latest LTS) configured out of the box. It also includes a small selection of other useful CLI utilities to improve the overall experience.  
+`powershell-toolbox` is based on `WolfiOS`. Its primary purpose is to be a dedicated container for Microsoft related technologies used during development. It contains [PowerShell](https://github.com/PowerShell/PowerShell), [Azure CLI](https://github.com/Azure/azure-cli) and [.NET](https://github.com/dotnet/core) (latest LTS) configured out of the box. It also includes a small selection of other useful CLI utilities to improve the overall experience.
 
 # Stats
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Centralized repository of containers designed for Toolbox/Distrobox with batteri
 - `fedora-toolbox` - a Fedora base image
 - `wolfi-toolbox` - a WolfiOS base image
 - `bluefin-cli` - a WolfiOS based image with Homebrew and a strongly opinionated default experience
+- `powershell-toolbox` - a WolfiOS based image with PowerShell and other Microsoft related tooling 
 
-It is strongly recommended that the [Prompt terminal](https://gitlab.gnome.org/chergert/prompt) be used with these toolboxes and is the default experience in both [Bazzite](https://bazzite.gg) and [Bluefin](https://projectbluefin.io).
+It is strongly recommended that the [Ptyxis terminal](https://gitlab.gnome.org/chergert/ptyxis) be used with these toolboxes and is the default experience in both [Bazzite](https://bazzite.gg) and [Bluefin](https://projectbluefin.io).
 
 ## Automatic Toolbox Startup
 
@@ -22,7 +23,7 @@ It is strongly recommended that the [Prompt terminal](https://gitlab.gnome.org/c
 
 Podman supports starting containers via a systemd generator. Quadlets replaced the `podman generate systemd` command and provide a method to create a systemd service for managing your container. The generated unit file can automatically start your container on login, automatically check for updates from the registry, and automatically clean-up the container and any transient volumes when the container stops. This provides an ideal way to have a clean slate on each login.
 
-Inside the quadlets directory are example quadlets each of the toolboxes listed above. Distrobox and Toolbox provide a convenient way to integrate the containers into your host.`ubuntu-toolbox` and `fedora-toolbox` can use either toolbox or distrobox. `wolfi-toolbox` and `bluefin-cli` are currently only compatible with distrobox. 
+Inside the quadlets directory are example quadlets each of the toolboxes listed above. Distrobox and Toolbox provide a convenient way to integrate the containers into your host.`ubuntu-toolbox` and `fedora-toolbox` can use either toolbox or distrobox. `wolfi-toolbox`, `bluefin-cli` and `powershell-toolbox` (WolfiOS base) are currently only compatible with distrobox. 
 
 The quadlets mimic the create and enter commands to setup the container. You can use these by copying them to `~/.config/containers/systemd`. When using the Prompt terminal, they will appear in the menu as available containers. The `Exec=` line of the distrobox quadlets can be modified to include additional packages.
 
@@ -40,7 +41,7 @@ To utilize these, place the user service file in `~/.config/systemd/user` and ma
 
 `bluefin-cli` is built from `wolfi-toolbox`. It contains [Homebrew](https://brew.sh/) configured out of the box. The brew state is bind mounted to a directory from your `$HOME`. Unlike the other toolboxes, `bluefin-cli` is intended for CLI applications _only_. 
 
-It's primary purpose is to be **the** command line companion to Flathub-enabled systems by providing access to one of the largest command line repositories in the world via homebrew. Developer dependencies should be managed seperately via [devcontainers](https://github.com/devcontainers).  
+Its primary purpose is to be **the** command line companion to Flathub-enabled systems by providing access to one of the largest command line repositories in the world via homebrew. Developer dependencies should be managed seperately via [devcontainers](https://github.com/devcontainers).  
 
 The default configuration destroys and updates this container daily so that the toolbox is built from scratch.
 
@@ -51,6 +52,10 @@ The [WolfiOS](https://edu.chainguard.dev/open-source/wolfi/overview/) apk packag
 The intended endstate of `bluefin-cli` is a fully automated declarative config managed via git using Wolfi packages for clean rebuilds daily. `brew` is used to fill out the "long tail" of existing software.
 
 Both `bluefin-cli` and `wolfi-toolbox` have Wolfi developer variants built from the Wolfi SDK image, intended for Wolfi package and image development. They include utilities such as melange, wolfictl, and apko. These images are labelled `bluefin-dx-cli` and `wolfi-dx-toolbox`.
+
+### PowerShell-Toolbox
+
+`powershell-toolbox` is based on `WolfiOS`. Its primary purpose is to be a dedicated container for Microsoft related technologies used during development. It contains [PowerShell](https://github.com/PowerShell/PowerShell), [Azure CLI](https://github.com/Azure/azure-cli) and [.NET](https://github.com/dotnet/core) (latest LTS) configured out of the box. It also includes a small selection of other useful CLI utilities to improve the overall experience.  
 
 # Stats
 

--- a/toolboxes/powershell-toolbox/Containerfile.powershell
+++ b/toolboxes/powershell-toolbox/Containerfile.powershell
@@ -6,17 +6,30 @@ LABEL com.github.containers.toolbox="true" \
 	usage="This image is meant to be used with the toolbox or distrobox command" \
 	description="A container image with integrated Powershell and Microsoft tooling for development environments."
 
-# COPY ./toolboxes/powershell-toolbox/packages.powershell /tmp
-COPY packages.powershell /tmp
-
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-
-RUN apk upgrade && \
-	grep -v '^#' /tmp/packages.powershell | xargs apk add --no-cache
-
 ENV POWERSHELL_TELEMETRY_OPTOUT=1
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
-RUN az config set core.collect_telemetry=no && \
-	rm -rf /tmp/*
+# COPY ./toolboxes/powershell-toolbox/packages.powershell /tmp
+COPY packages.powershell /tmp
+# COPY ./toolboxes/powershell-toolbox/profile.ps1 /tmp/Microsoft.PowerShell_profile.ps1
+COPY profile.ps1 /tmp/Microsoft.PowerShell_profile.ps1
+
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+
+RUN apk upgrade \
+	&& grep -v '^#' /tmp/packages.powershell | xargs apk add --no-cache \
+  && dotnet tool install --global PowerShell \
+  && az config set core.collect_telemetry=no \
+  && curl -s https://ohmyposh.dev/install.sh | bash -s \
+  && curl -LSfs https://raw.githubusercontent.com/cantino/mcfly/master/ci/install.sh | sh -s -- --git cantino/mcfly \
+  && mkdir -p ~/.config/powershell \
+  && cp /tmp/Microsoft.PowerShell_profile.ps1 ~/.config/powershell \
+  && mkdir -p ~/.local/share/powershell/PSReadLine \
+  && touch ~/.local/share/powershell/PSReadLine/ConsoleHost_history.txt \
+  && rm -rf /tmp/*
+
+ENV DOTNET_TOOLS=~/.dotnet/tools
+ENV PATH=${DOTNET_TOOLS}:${PATH}
+
+
 

--- a/toolboxes/powershell-toolbox/Containerfile.powershell
+++ b/toolboxes/powershell-toolbox/Containerfile.powershell
@@ -25,6 +25,7 @@ RUN apk upgrade \
   && curl -LSfs https://raw.githubusercontent.com/cantino/mcfly/master/ci/install.sh | sh -s -- --git cantino/mcfly \
   && mkdir -p ~/.config/powershell \
   && cp /tmp/Microsoft.PowerShell_profile.ps1 ~/.config/powershell \
+  && cp /tmp/profile.ps1 "$(~/.dotnet/tools/pwsh -Command "\$PROFILE.AllUsersAllHosts")" \
   && mkdir -p ~/.local/share/powershell/PSReadLine \
   && touch ~/.local/share/powershell/PSReadLine/ConsoleHost_history.txt \
   && rm -rf /tmp/*

--- a/toolboxes/powershell-toolbox/Containerfile.powershell
+++ b/toolboxes/powershell-toolbox/Containerfile.powershell
@@ -21,6 +21,7 @@ RUN apk upgrade \
   && dotnet tool install --global PowerShell \
   && az config set core.collect_telemetry=no \
   && curl -s https://ohmyposh.dev/install.sh | bash -s \
+  && curl -s https://ohmyposh.dev/install.sh | bash -s -- -t /usr/local/share/oh-my-posh/themes \
   && curl -LSfs https://raw.githubusercontent.com/cantino/mcfly/master/ci/install.sh | sh -s -- --git cantino/mcfly \
   && mkdir -p ~/.config/powershell \
   && cp /tmp/Microsoft.PowerShell_profile.ps1 ~/.config/powershell \

--- a/toolboxes/powershell-toolbox/Containerfile.powershell
+++ b/toolboxes/powershell-toolbox/Containerfile.powershell
@@ -9,10 +9,10 @@ LABEL com.github.containers.toolbox="true" \
 ENV POWERSHELL_TELEMETRY_OPTOUT=1
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
-# COPY packages.powershell /tmp
-# COPY profile.ps1 /tmp/Microsoft.PowerShell_profile.ps1
-COPY ./toolboxes/powershell-toolbox/packages.powershell /tmp
-COPY ./toolboxes/powershell-toolbox/profile.ps1 /tmp/Microsoft.PowerShell_profile.ps1
+COPY packages.powershell /tmp
+COPY profile.ps1 /tmp
+# COPY ./toolboxes/powershell-toolbox/packages.powershell /tmp
+# COPY ./toolboxes/powershell-toolbox/profile.ps1 /tmp
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 

--- a/toolboxes/powershell-toolbox/Containerfile.powershell
+++ b/toolboxes/powershell-toolbox/Containerfile.powershell
@@ -9,10 +9,10 @@ LABEL com.github.containers.toolbox="true" \
 ENV POWERSHELL_TELEMETRY_OPTOUT=1
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
-# COPY ./toolboxes/powershell-toolbox/packages.powershell /tmp
-COPY packages.powershell /tmp
-# COPY ./toolboxes/powershell-toolbox/profile.ps1 /tmp/Microsoft.PowerShell_profile.ps1
-COPY profile.ps1 /tmp/Microsoft.PowerShell_profile.ps1
+# COPY packages.powershell /tmp
+# COPY profile.ps1 /tmp/Microsoft.PowerShell_profile.ps1
+COPY ./toolboxes/powershell-toolbox/packages.powershell /tmp
+COPY ./toolboxes/powershell-toolbox/profile.ps1 /tmp/Microsoft.PowerShell_profile.ps1
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 

--- a/toolboxes/powershell-toolbox/Containerfile.powershell
+++ b/toolboxes/powershell-toolbox/Containerfile.powershell
@@ -20,11 +20,8 @@ RUN apk upgrade \
 	&& grep -v '^#' /tmp/packages.powershell | xargs apk add --no-cache \
   && dotnet tool install --global PowerShell \
   && az config set core.collect_telemetry=no \
-  && curl -s https://ohmyposh.dev/install.sh | bash -s \
   && curl -s https://ohmyposh.dev/install.sh | bash -s -- -t /usr/local/share/oh-my-posh/themes \
   && curl -LSfs https://raw.githubusercontent.com/cantino/mcfly/master/ci/install.sh | sh -s -- --git cantino/mcfly \
-  && mkdir -p ~/.config/powershell \
-  && cp /tmp/Microsoft.PowerShell_profile.ps1 ~/.config/powershell \
   && cp /tmp/profile.ps1 "$(~/.dotnet/tools/pwsh -Command "\$PROFILE.AllUsersAllHosts")" \
   && mkdir -p ~/.local/share/powershell/PSReadLine \
   && touch ~/.local/share/powershell/PSReadLine/ConsoleHost_history.txt \

--- a/toolboxes/powershell-toolbox/packages.powershell
+++ b/toolboxes/powershell-toolbox/packages.powershell
@@ -1,3 +1,11 @@
 az
+bat
 dotnet-8-sdk
-powershell
+eza
+fd
+fzf
+gawk
+jq
+ripgrep
+sed
+zoxide

--- a/toolboxes/powershell-toolbox/profile.ps1
+++ b/toolboxes/powershell-toolbox/profile.ps1
@@ -1,0 +1,64 @@
+# Oh My Posh
+oh-my-posh init pwsh --config 'https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/mt.omp.json' | Invoke-Expression
+
+# Zoxide
+Invoke-Expression (& { (zoxide init powershell | Out-String) })
+
+# McFly
+Invoke-Expression -Command $(mcfly init powershell | Out-String)
+# $env:MCFLY_LIGHT = "TRUE"
+
+# PSReadLine
+if ((Get-InstalledModule `
+    -Name "PSReadLine" `
+    -ErrorAction SilentlyContinue) -eq $null) {
+
+    Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted
+    Install-Module -Name PSReadLine -AllowPrerelease -Force
+    Set-PSRepository -Name 'PSGallery' -InstallationPolicy Untrusted
+}
+
+# PSFzf
+if ((Get-InstalledModule `
+    -Name "PSFzf" `
+    -ErrorAction SilentlyContinue) -eq $null) {
+
+    Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted
+    Install-Module -Name PSFzf
+    Set-PSRepository -Name 'PSGallery' -InstallationPolicy Untrusted
+}
+
+# Set PSReadLine options to show the history of typed commands
+Set-PSReadLineOption -PredictionSource History
+Set-PSReadLineOption -PredictionViewStyle ListView
+Set-PSReadLineOption -EditMode Windows
+
+# Set shortcuts to begin fzf searching
+Set-PsFzfOption -PSReadlineChordProvider 'Ctrl+t' -PSReadlineChordReverseHistory 'Ctrl+f'
+
+# PowerShell parameter completion shim for the dotnet CLI
+Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock {
+     param($commandName, $wordToComplete, $cursorPosition)
+         dotnet complete --position $cursorPosition "$wordToComplete" | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+         }
+ }
+
+# PowerShell parameter completion shim for Azure CLI
+Register-ArgumentCompleter -Native -CommandName az -ScriptBlock {
+    param($commandName, $wordToComplete, $cursorPosition)
+    $completion_file = New-TemporaryFile
+    $env:ARGCOMPLETE_USE_TEMPFILES = 1
+    $env:_ARGCOMPLETE_STDOUT_FILENAME = $completion_file
+    $env:COMP_LINE = $wordToComplete
+    $env:COMP_POINT = $cursorPosition
+    $env:_ARGCOMPLETE = 1
+    $env:_ARGCOMPLETE_SUPPRESS_SPACE = 0
+    $env:_ARGCOMPLETE_IFS = "`n"
+    $env:_ARGCOMPLETE_SHELL = 'powershell'
+    az 2>&1 | Out-Null
+    Get-Content $completion_file | Sort-Object | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", $_)
+    }
+    Remove-Item $completion_file, Env:\_ARGCOMPLETE_STDOUT_FILENAME, Env:\ARGCOMPLETE_USE_TEMPFILES, Env:\COMP_LINE, Env:\COMP_POINT, Env:\_ARGCOMPLETE, Env:\_ARGCOMPLETE_SUPPRESS_SPACE, Env:\_ARGCOMPLETE_IFS, Env:\_ARGCOMPLETE_SHELL
+}

--- a/toolboxes/powershell-toolbox/profile.ps1
+++ b/toolboxes/powershell-toolbox/profile.ps1
@@ -4,10 +4,6 @@ oh-my-posh init pwsh --config 'https://raw.githubusercontent.com/JanDeDobbeleer/
 # Zoxide
 Invoke-Expression (& { (zoxide init powershell | Out-String) })
 
-# McFly
-Invoke-Expression -Command $(mcfly init powershell | Out-String)
-# $env:MCFLY_LIGHT = "TRUE"
-
 # PSReadLine
 if ((Get-InstalledModule `
     -Name "PSReadLine" `
@@ -35,6 +31,10 @@ Set-PSReadLineOption -EditMode Windows
 
 # Set shortcuts to begin fzf searching
 Set-PsFzfOption -PSReadlineChordProvider 'Ctrl+t' -PSReadlineChordReverseHistory 'Ctrl+f'
+
+# McFly
+Invoke-Expression -Command $(mcfly init powershell | Out-String)
+# $env:MCFLY_LIGHT = "TRUE"
 
 # PowerShell parameter completion shim for the dotnet CLI
 Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock {

--- a/toolboxes/powershell-toolbox/profile.ps1
+++ b/toolboxes/powershell-toolbox/profile.ps1
@@ -34,6 +34,8 @@ Set-PsFzfOption -PSReadlineChordProvider 'Ctrl+t' -PSReadlineChordReverseHistory
 
 # McFly
 Invoke-Expression -Command $(mcfly init powershell | Out-String)
+$env:MCFLY_RESULTS=50
+# $env:MCFLY_RESULTS_SORT="LAST_RUN" # defaults to RANK
 # $env:MCFLY_LIGHT = "TRUE"
 
 # PowerShell parameter completion shim for the dotnet CLI


### PR DESCRIPTION
# Improve PowerShell toolbox experience

Relates to #11 

## Description

Improve the UX experience of the new PowerShell toolbox.

### Proposed Changes

- Extend package list with various CLI utils
  - bat
  - eza
  - fd
  - fzf
  - gawk
  - jq
  - ripgrep
  - sed
  - zoxide
- Fix missing PowerShell modules issue by installing PowerShell as a .[NET Global tool](https://learn.microsoft.com/en-us/powershell/scripting/install/install-other-linux?view=powershell-7.4#install-as-a-net-global-tool)
  - Add initial [PowerShell profile](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.4) with the following features:
    - [Oh My Posh](https://ohmyposh.dev/) integration with [mt](https://ohmyposh.dev/docs/themes#mt) theme 
    - [Zoxide](https://github.com/ajeetdsouza/zoxide) integration
    - [McFly](https://github.com/cantino/mcfly) integration via CTRL-r
    - [PSReadline](https://github.com/PowerShell/PSReadLine) integration
    - [PSFzf](https://github.com/kelleyma49/PSFzf) integration via CTRL-t and CTRL-f
- Autocomplete for Azure CLI
- Autocomplete for .NET (dotnet cli)
- Update README

#### Notes

The initial launch of `pwsh` will take longer than usual since some utils need to be downloaded. 