### PR TITLE
chore: push images with zstd:chunked

### DIFF
--- a/.github/workflows/build-blincusui-app.yml
+++ b/.github/workflows/build-blincusui-app.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -86,6 +86,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          extra-args: |
+            --compression-format=zstd:chunked
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.5.0

--- a/.github/workflows/build-bluefin-toolbox.yml
+++ b/.github/workflows/build-bluefin-toolbox.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -90,6 +90,8 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
+          extra-args: |
+            --compression-format=zstd:chunked
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-fedora-toolbox.yml
+++ b/.github/workflows/build-fedora-toolbox.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -78,6 +78,9 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
+          extra-args: |
+            --compression-format=zstd:chunked
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build-incus-app.yml
+++ b/.github/workflows/build-incus-app.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -87,6 +87,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          extra-args: |
+            --compression-format=zstd:chunked
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.5.0

--- a/.github/workflows/build-powershell.yml
+++ b/.github/workflows/build-powershell.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-ubuntu-toolbox.yml
+++ b/.github/workflows/build-ubuntu-toolbox.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -87,6 +87,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          extra-args: |
+            --compression-format=zstd:chunked
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.5.0

--- a/.github/workflows/build-wolfi-toolbox.yml
+++ b/.github/workflows/build-wolfi-toolbox.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -97,6 +97,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          extra-args: |
+            --compression-format=zstd:chunked
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.5.0


### PR DESCRIPTION
Do not merge yet! https://www.redhat.com/sysadmin/faster-container-image-pulls

Met with the podman team on this and got the demo. Note that all the stuff required for bootc and rpm-ostree are in flight and inprogress. However this has been in podman and docker for a while now, so the toolboxes are a perfect place to get some savings.

I built this in castrojo/bluefin-cli. Needs to be on an ubuntu-24.04 builder so that the newer version of podman is on there. Then we add `--compression-format=zstd:chunked` to the podman push step. Podman and docker will know it's zstd:chunked and just do the right thing. 

    podman pull ghcr.io/castrojo/bluefin-cli

And make note of the output. Leaving this as draft so we can observe what a few days of updates looks like in practice. 


