### PR TITLE
revert: "chore: push images with zstd:chunked"

### DIFF
--- a/.github/workflows/build-blincusui-app.yml
+++ b/.github/workflows/build-blincusui-app.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -86,8 +86,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          extra-args: |
-            --compression-format=zstd:chunked
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.5.0

--- a/.github/workflows/build-bluefin-toolbox.yml
+++ b/.github/workflows/build-bluefin-toolbox.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -90,8 +90,6 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-          extra-args: |
-            --compression-format=zstd:chunked
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-fedora-toolbox.yml
+++ b/.github/workflows/build-fedora-toolbox.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -78,9 +78,6 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-          extra-args: |
-            --compression-format=zstd:chunked
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build-incus-app.yml
+++ b/.github/workflows/build-incus-app.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -87,8 +87,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          extra-args: |
-            --compression-format=zstd:chunked
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.5.0

--- a/.github/workflows/build-powershell.yml
+++ b/.github/workflows/build-powershell.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-ubuntu-toolbox.yml
+++ b/.github/workflows/build-ubuntu-toolbox.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -87,8 +87,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          extra-args: |
-            --compression-format=zstd:chunked
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.5.0

--- a/.github/workflows/build-wolfi-toolbox.yml
+++ b/.github/workflows/build-wolfi-toolbox.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -97,8 +97,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          extra-args: |
-            --compression-format=zstd:chunked
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.5.0


### PR DESCRIPTION
Reverts ublue-os/toolboxes#101

We can't swap until ubuntu-24.04 runners are out of beta in GitHub, otherwise builds downstream will break. https://universal-blue.discourse.group/t/the-bluefin-cli-container/704/16