### PR TITLE
fix(ubuntu): Add glib for VSCode file trashing

### DIFF
--- a/toolboxes/ubuntu-toolbox/packages.ubuntu
+++ b/toolboxes/ubuntu-toolbox/packages.ubuntu
@@ -46,6 +46,7 @@ libgl1
 libgl1-amber-dri
 libgl1-mesa-dri
 libglapi-mesa
+libglib2.0-bin
 libglvnd0
 libglx0
 libglx-mesa0


### PR DESCRIPTION
Visual Studio Code(and presumably Codium) needs this glib binary package in order to properly trash files - as opposed to deleting them permanently.