### PR TITLE
feat(bluefin-cli): Add alias for cat

### DIFF
--- a/toolboxes/bluefin-cli/files/etc/profile.d/modern-unix.sh
+++ b/toolboxes/bluefin-cli/files/etc/profile.d/modern-unix.sh
@@ -18,3 +18,6 @@ alias cd='cd' 2>/dev/null
 
 # Fd for find
 alias find='fd' 2>/dev/null
+
+# bat for cat
+alias cat='bat --style=plain --pager=never' 2>/dev/null


### PR DESCRIPTION
Fixes #67

This adds an alias for cat to use bat without line numbers or paging so
we get the same behaviour as cat with the syntax highlighting from bat.
