### PR TITLE
chore(arch): move to centralized repo

### DIFF
--- a/.github/workflows/build-arch-toolbox.yml
+++ b/.github/workflows/build-arch-toolbox.yml
@@ -1,4 +1,4 @@
-name: Build Arch-Distrobox
+name: Build Arch-Toolbox
 on:
   schedule:
     - cron: '20 18 * * *'  # 8:20pm everyday

--- a/.github/workflows/build-arch-toolbox.yml
+++ b/.github/workflows/build-arch-toolbox.yml
@@ -80,10 +80,7 @@ jobs:
           images: |
             ${{ env.IMAGE_NAME }}
           labels: |
-            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
-            org.opencontainers.image.version=${{ steps.labels.outputs.VERSION }}
-            org.opencontainers.image.description=These images are not meant to be used as a host operating system. Please see arch-distrobox for more information.
-            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/arch-distrobox/main/README.md
+            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/boxkit/main/README.md
 
       # Build image using Buildah action
       - name: Build Image

--- a/.github/workflows/build-arch-toolbox.yml
+++ b/.github/workflows/build-arch-toolbox.yml
@@ -3,19 +3,6 @@ on:
   schedule:
     - cron: '20 18 * * *'  # 8:20pm everyday
   pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
-  pull_request_review:
-    type: [submitted]
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
   merge_group:
   workflow_dispatch:
 env:

--- a/.github/workflows/build-arch-toolbox.yml
+++ b/.github/workflows/build-arch-toolbox.yml
@@ -1,0 +1,167 @@
+name: Build Arch-Distrobox
+on:
+  schedule:
+    - cron: '20 18 * * *'  # 8:20pm everyday
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+  pull_request_review:
+    type: [submitted]
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+  merge_group:
+  workflow_dispatch:
+env:
+    IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+
+jobs:
+  push-ghcr:
+    name: Build and push image
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        base_name: [arch-toolbox, arch-toolbox-amdgpupro]
+        include:
+          - is_latest_version: true
+            is_stable_version: true
+    steps:
+      # Checkout push-to-registry action GitHub repository
+      - name: Checkout Push to Registry action
+        uses: actions/checkout@v4
+
+      - name: Matrix Variables
+        run: |
+          echo "IMAGE_NAME=${{ matrix.base_name }}" >> $GITHUB_ENV
+
+      - name: Generate tags
+        id: generate-tags
+        shell: bash
+        run: |
+          # Generate a timestamp for creating an image version history
+          TIMESTAMP="$(date +%Y%m%d)"
+          COMMIT_TAGS=()
+          BUILD_TAGS=()
+          # Have tags for tracking builds during pull request
+          SHA_SHORT="${GITHUB_SHA::7}"
+          COMMIT_TAGS+=("pr-${{ github.event.pull_request.number }}")
+          COMMIT_TAGS+=("${SHA_SHORT}")
+          if [[ "${{ matrix.is_latest_version }}" == "true" ]] && \
+             [[ "${{ matrix.is_stable_version }}" == "true" ]]; then
+              COMMIT_TAGS+=("pr-${{ github.event.pull_request.number }}")
+              COMMIT_TAGS+=("${SHA_SHORT}")
+          fi
+
+          BUILD_TAGS=("${TIMESTAMP}")
+
+          if [[ "${{ matrix.is_latest_version }}" == "true" ]] && \
+             [[ "${{ matrix.is_stable_version }}" == "true" ]]; then
+              BUILD_TAGS+=("latest")
+          fi
+
+          if [[ "${{ github.event_name }}" == "pull_request_review" ]]; then
+              echo "Generated the following commit tags: "
+              for TAG in "${COMMIT_TAGS[@]}"; do
+                  echo "${TAG}"
+              done
+              alias_tags=("${COMMIT_TAGS[@]}")
+          else
+              alias_tags=("${BUILD_TAGS[@]}")
+          fi
+          echo "Generated the following build tags: "
+          for TAG in "${BUILD_TAGS[@]}"; do
+              echo "${TAG}"
+          done
+          echo "alias_tags=${alias_tags[*]}" >> $GITHUB_OUTPUT
+
+      # Build metadata
+      - name: Image Metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+            org.opencontainers.image.version=${{ steps.labels.outputs.VERSION }}
+            org.opencontainers.image.description=These images are not meant to be used as a host operating system. Please see arch-distrobox for more information.
+            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/arch-distrobox/main/README.md
+
+      # Build image using Buildah action
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          containerfiles: |
+            ./toolboxes/arch-toolbox/Containerfile.arch
+            ./toolboxes/arch-toolbox/Containerfile.archamdgpupro
+          image: ${{ env.IMAGE_NAME }}
+          tags: |
+            ${{ steps.generate-tags.outputs.alias_tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          oci: false
+          extra-args: |
+            --target=${{ matrix.base_name }} --security-opt=seccomp=unconfined
+
+      # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
+      # https://github.com/macbre/push-to-ghcr/issues/12
+      - name: Lowercase Registry
+        id: registry_case
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ env.IMAGE_REGISTRY }}
+
+      # Push the image to GHCR (Image Registry)
+      - name: Push To GHCR
+        uses: redhat-actions/push-to-registry@v2
+        id: push
+        if: github.event_name != 'pull_request'
+        env:
+          REGISTRY_USER: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ github.token }}
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          tags: ${{ steps.build_image.outputs.tags }}
+          registry: ${{ steps.registry_case.outputs.lowercase }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+          extra-args: |
+            --disable-content-trust
+            --compression-format=zstd:chunked
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Sign container
+      - uses: sigstore/cosign-installer@v3.1.2
+        if: github.event_name != 'pull_request'
+
+      - name: Sign container image
+        if: github.event_name != 'pull_request'
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
+        env:
+          TAGS: ${{ steps.push.outputs.digest }}
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+
+      - name: Echo outputs
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "${{ toJSON(steps.push.outputs) }}"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Centralized repository of containers designed for Toolbox/Distrobox with batteri
 - `ubuntu-toolbox` - an Ubuntu base image
 - `debian-toolbox` - a Debian base image
 - `fedora-toolbox` - a Fedora base image
+- `arch-toolbox` - an Arch base image
+- `arch-toolbox-amdgpupro` - an Arch base image with proprietary AMD GPU drivers
 - `wolfi-toolbox` - a WolfiOS base image
 - `bluefin-cli` - a WolfiOS based image with Homebrew and a strongly opinionated default experience
 - `powershell-toolbox` - a WolfiOS based image with PowerShell and other Microsoft related tooling

--- a/quadlets/arch-toolbox/arch-distrobox-amdgpupro-quadlet.container
+++ b/quadlets/arch-toolbox/arch-distrobox-amdgpupro-quadlet.container
@@ -8,7 +8,7 @@ ContainerName=arch-distrobox-quadlet
 Environment=SHELL=%s
 Environment=HOME=%h
 Environment=container=podman
-Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" -- " "
+Exec=--verbose --name %u --user %U --group %G --home %h --init "0" -- " "
 Image=ghcr.io/ublue-os/arch-toolbox:latest
 HostName=arch-toolbox.%l
 Label=manager=distrobox

--- a/quadlets/arch-toolbox/arch-distrobox-amdgpupro-quadlet.container
+++ b/quadlets/arch-toolbox/arch-distrobox-amdgpupro-quadlet.container
@@ -1,0 +1,40 @@
+[Unit]
+Description=Arch Toolbox for your distrobox fun
+
+[Container]
+Annotation=run.oci.keep_original_groups=1
+AutoUpdate=registry
+ContainerName=arch-distrobox-quadlet
+Environment=SHELL=%s
+Environment=HOME=%h
+Environment=container=podman
+Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" -- " "
+Image=ghcr.io/ublue-os/arch-toolbox:latest
+HostName=arch-toolbox.%l
+Label=manager=distrobox
+Network=host
+PodmanArgs=--entrypoint /usr/bin/entrypoint
+PodmanArgs=--ipc host
+PodmanArgs=--pid host
+PodmanArgs=--privileged
+PodmanArgs=--security-opt label=disable
+PodmanArgs=--security-opt apparmor=unconfined
+Ulimit=host
+User=root:root
+UserNS=keep-id
+Volume=/:/run/host:rslave
+Volume=/tmp:/tmp:rslave
+Volume=/usr/bin/distrobox-init:/usr/bin/entrypoint:ro
+Volume=/usr/bin/distrobox-export:/usr/bin/distrobox-export:ro
+Volume=/usr/bin/distrobox-host-exec:/usr/bin/distrobox-host-exec:ro
+Volume=%h:%h:rslave
+Volume=/dev:/dev:rslave
+Volume=/sys:/sys:rslave
+Volume=/dev/pts
+Volume=/dev/null:/dev/ptmx
+Volume=/sys/fs/selinux
+Volume=/var/log/journal
+Volume=/var/home/%u:/var/home/%u:rslave
+Volume=%t:%t:rslave
+Volume=/etc/hosts:/etc/hosts:ro
+Volume=/etc/resolv.conf:/etc/resolv.conf:ro

--- a/quadlets/arch-toolbox/arch-distrobox-quadlet.container
+++ b/quadlets/arch-toolbox/arch-distrobox-quadlet.container
@@ -1,0 +1,40 @@
+[Unit]
+Description=Fedora Toolbox for your distrobox fun
+
+[Container]
+Annotation=run.oci.keep_original_groups=1
+AutoUpdate=registry
+ContainerName=fedora-distrobox-quadlet
+Environment=SHELL=%s
+Environment=HOME=%h
+Environment=container=podman
+Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" -- " "
+Image=ghcr.io/ublue-os/fedora-toolbox:latest
+HostName=fedora-toolbox.%l
+Label=manager=distrobox
+Network=host
+PodmanArgs=--entrypoint /usr/bin/entrypoint
+PodmanArgs=--ipc host
+PodmanArgs=--pid host
+PodmanArgs=--privileged
+PodmanArgs=--security-opt label=disable
+PodmanArgs=--security-opt apparmor=unconfined
+Ulimit=host
+User=root:root
+UserNS=keep-id
+Volume=/:/run/host:rslave
+Volume=/tmp:/tmp:rslave
+Volume=/usr/bin/distrobox-init:/usr/bin/entrypoint:ro
+Volume=/usr/bin/distrobox-export:/usr/bin/distrobox-export:ro
+Volume=/usr/bin/distrobox-host-exec:/usr/bin/distrobox-host-exec:ro
+Volume=%h:%h:rslave
+Volume=/dev:/dev:rslave
+Volume=/sys:/sys:rslave
+Volume=/dev/pts
+Volume=/dev/null:/dev/ptmx
+Volume=/sys/fs/selinux
+Volume=/var/log/journal
+Volume=/var/home/%u:/var/home/%u:rslave
+Volume=%t:%t:rslave
+Volume=/etc/hosts:/etc/hosts:ro
+Volume=/etc/resolv.conf:/etc/resolv.conf:ro

--- a/quadlets/arch-toolbox/arch-distrobox-quadlet.container
+++ b/quadlets/arch-toolbox/arch-distrobox-quadlet.container
@@ -1,16 +1,16 @@
 [Unit]
-Description=Fedora Toolbox for your distrobox fun
+Description=Arch Toolbox for your distrobox fun
 
 [Container]
 Annotation=run.oci.keep_original_groups=1
 AutoUpdate=registry
-ContainerName=fedora-distrobox-quadlet
+ContainerName=arch-distrobox-quadlet
 Environment=SHELL=%s
 Environment=HOME=%h
 Environment=container=podman
 Exec=--verbose --name %u --user %U --group %G --home %h --init "0" --nvidia "1" -- " "
-Image=ghcr.io/ublue-os/fedora-toolbox:latest
-HostName=fedora-toolbox.%l
+Image=ghcr.io/ublue-os/arch-toolbox:latest
+HostName=arch-toolbox.%l
 Label=manager=distrobox
 Network=host
 PodmanArgs=--entrypoint /usr/bin/entrypoint

--- a/quadlets/arch-toolbox/arch-toolbox-amdgpupro-quadlet.container
+++ b/quadlets/arch-toolbox/arch-toolbox-amdgpupro-quadlet.container
@@ -1,0 +1,35 @@
+[Unit]
+Description=Arch Toolbox for your toolbox needs
+
+[Container]
+AutoUpdate=registry
+ContainerName=arch-toolbox-quadlet
+Environment=TOOLBOX_PATH=/usr/bin/toolbox
+Environment=XDG_RUNTIME_DIR=%t
+Exec=init-container --gid %G --home %h --shell %s --uid %U --user %u --home-link --media-link --mnt-link
+HostName=arch-toolbox-quadlet
+Image=ghcr.io/ublue-os/arch-toolbox:latest
+Mount=type=devpts,destination=/dev/pts
+Network=host
+PodmanArgs=--cgroupns host
+PodmanArgs=--ipc host
+PodmanArgs=--label com.github.containers.toolbox=true
+PodmanArgs=--no-hosts
+PodmanArgs=--pid host
+PodmanArgs=--privileged
+PodmanArgs=--security-opt label=disable
+PodmanArgs=--entrypoint toolbox
+Ulimit=host
+UserNS=keep-id
+User=root:root
+Volume=/:/run/host:rslave
+Volume=/dev:/dev:rslave
+Volume=/run/dbus/system_bus_socket:/run/dbus/system_bus_socket
+Volume=/var/%h:/var/%h:rslave
+Volume=/usr/bin/toolbox:/usr/bin/toolbox:ro
+Volume=%t:%t
+Volume=/run/avahi-daemon/socket:/run/avahi-daemon/socket
+Volume=/run/.heim_org.h5l.kcm-socket:/run/.heim_org.h5l.kcm-socket
+Volume=/run/pcscd/pcscd.comm:/run/pcscd/pcscd.comm
+Volume=/run/media:/run/media:rslave
+Volume=/etc/profile.d/toolbox.sh:/etc/profile.d/toolbox.sh:ro

--- a/quadlets/arch-toolbox/arch-toolbox-quadlet.container
+++ b/quadlets/arch-toolbox/arch-toolbox-quadlet.container
@@ -1,0 +1,35 @@
+[Unit]
+Description=Fedora Toolbox for your toolbox needs
+
+[Container]
+AutoUpdate=registry
+ContainerName=fedora-toolbox-quadlet
+Environment=TOOLBOX_PATH=/usr/bin/toolbox
+Environment=XDG_RUNTIME_DIR=%t
+Exec=init-container --gid %G --home %h --shell %s --uid %U --user %u --home-link --media-link --mnt-link
+HostName=fedora-toolbox-quadlet
+Image=ghcr.io/ublue-os/fedora-toolbox:latest
+Mount=type=devpts,destination=/dev/pts
+Network=host
+PodmanArgs=--cgroupns host
+PodmanArgs=--ipc host
+PodmanArgs=--label com.github.containers.toolbox=true
+PodmanArgs=--no-hosts
+PodmanArgs=--pid host
+PodmanArgs=--privileged
+PodmanArgs=--security-opt label=disable
+PodmanArgs=--entrypoint toolbox
+Ulimit=host
+UserNS=keep-id
+User=root:root
+Volume=/:/run/host:rslave
+Volume=/dev:/dev:rslave
+Volume=/run/dbus/system_bus_socket:/run/dbus/system_bus_socket
+Volume=/var/%h:/var/%h:rslave
+Volume=/usr/bin/toolbox:/usr/bin/toolbox:ro
+Volume=%t:%t
+Volume=/run/avahi-daemon/socket:/run/avahi-daemon/socket
+Volume=/run/.heim_org.h5l.kcm-socket:/run/.heim_org.h5l.kcm-socket
+Volume=/run/pcscd/pcscd.comm:/run/pcscd/pcscd.comm
+Volume=/run/media:/run/media:rslave
+Volume=/etc/profile.d/toolbox.sh:/etc/profile.d/toolbox.sh:ro

--- a/quadlets/arch-toolbox/arch-toolbox-quadlet.container
+++ b/quadlets/arch-toolbox/arch-toolbox-quadlet.container
@@ -1,14 +1,14 @@
 [Unit]
-Description=Fedora Toolbox for your toolbox needs
+Description=Arch Toolbox for your toolbox needs
 
 [Container]
 AutoUpdate=registry
-ContainerName=fedora-toolbox-quadlet
+ContainerName=arch-toolbox-quadlet
 Environment=TOOLBOX_PATH=/usr/bin/toolbox
 Environment=XDG_RUNTIME_DIR=%t
 Exec=init-container --gid %G --home %h --shell %s --uid %U --user %u --home-link --media-link --mnt-link
-HostName=fedora-toolbox-quadlet
-Image=ghcr.io/ublue-os/fedora-toolbox:latest
+HostName=arch-toolbox-quadlet
+Image=ghcr.io/ublue-os/arch-toolbox:latest
 Mount=type=devpts,destination=/dev/pts
 Network=host
 PodmanArgs=--cgroupns host

--- a/systemd/arch-toolbox/arch-distrobox-amdgpupro-oneshot.service
+++ b/systemd/arch-toolbox/arch-distrobox-amdgpupro-oneshot.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Arch Toolbox with AMD GPU PRO for your distrobox fun
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/distrobox assemble create --replace -f /etc/distrobox/distrobox.ini -n arch-toolbox-amdgpupro
+ExecStart=/usr/bin/distrobox enter arch-toolbox-amdgpupro
+RemainAfterExit=true

--- a/systemd/arch-toolbox/arch-distrobox-amdgpupro.ini
+++ b/systemd/arch-toolbox/arch-distrobox-amdgpupro.ini
@@ -1,0 +1,9 @@
+[arch-toolbox-amdgpupro]
+image=ghcr.io/ublue-os/arch-toolbox-amdgpupro:latest
+init=false
+pull=false
+nvidia=true
+init_hooks=""
+additional_packages=""
+pre_init_hooks=""
+start_now=true

--- a/systemd/arch-toolbox/arch-distrobox-amdgpupro.ini
+++ b/systemd/arch-toolbox/arch-distrobox-amdgpupro.ini
@@ -2,7 +2,6 @@
 image=ghcr.io/ublue-os/arch-toolbox-amdgpupro:latest
 init=false
 pull=false
-nvidia=true
 init_hooks=""
 additional_packages=""
 pre_init_hooks=""

--- a/systemd/arch-toolbox/arch-distrobox-oneshot.service
+++ b/systemd/arch-toolbox/arch-distrobox-oneshot.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Arch Toolbox for your distrobox fun
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/distrobox assemble create --replace -f /etc/distrobox/distrobox.ini -n arch-toolbox
+ExecStart=/usr/bin/distrobox enter arch-toolbox
+RemainAfterExit=true

--- a/systemd/arch-toolbox/arch-distrobox.ini
+++ b/systemd/arch-toolbox/arch-distrobox.ini
@@ -1,0 +1,9 @@
+[arch-toolbox]
+image=ghcr.io/ublue-os/arch-toolbox:latest
+init=false
+pull=false
+nvidia=true
+init_hooks=""
+additional_packages=""
+pre_init_hooks=""
+start_now=true

--- a/toolboxes/arch-toolbox/Containerfile.arch
+++ b/toolboxes/arch-toolbox/Containerfile.arch
@@ -1,5 +1,9 @@
 FROM quay.io/toolbx/arch-toolbox AS arch-toolbox
 
+LABEL com.github.containers.toolbox="true" \
+      usage="This image is meant to be used with the toolbox or distrobox command" \
+      summary="A cloud-native terminal experience powered by Arch Linux"
+
 # Pacman Initialization
 # Create build user
 RUN sed -i 's/#Color/Color/g' /etc/pacman.conf && \

--- a/toolboxes/arch-toolbox/Containerfile.arch
+++ b/toolboxes/arch-toolbox/Containerfile.arch
@@ -1,0 +1,90 @@
+FROM quay.io/toolbx/arch-toolbox AS arch-toolbox
+
+# Pacman Initialization
+# Create build user
+RUN sed -i 's/#Color/Color/g' /etc/pacman.conf && \
+    printf "[multilib]\nInclude = /etc/pacman.d/mirrorlist\n" | tee -a /etc/pacman.conf && \
+    sed -i 's/#MAKEFLAGS="-j2"/MAKEFLAGS="-j$(nproc)"/g' /etc/makepkg.conf && \
+    pacman-key --init && pacman-key --populate && \
+    pacman -Syu --noconfirm && \
+    useradd -m --shell=/bin/bash build && usermod -L build && \
+    echo "build ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    echo "root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    pacman -S --clean --clean
+
+# Distrobox Integration
+RUN git clone https://github.com/89luca89/distrobox.git --single-branch /tmp/distrobox && \
+    cp /tmp/distrobox/distrobox-host-exec /usr/bin/distrobox-host-exec && \
+    ln -s /usr/bin/distrobox-host-exec /usr/bin/flatpak && \
+    wget https://github.com/1player/host-spawn/releases/download/$(cat /tmp/distrobox/distrobox-host-exec | grep host_spawn_version= | cut -d "\"" -f 2)/host-spawn-$(uname -m) -O /usr/bin/host-spawn && \
+    chmod +x /usr/bin/host-spawn && \
+    rm -drf /tmp/distrobox
+
+# Install packages Distrobox adds automatically, this speeds up first launch
+RUN pacman -S \
+        adw-gtk-theme \
+        bash-completion \
+        bc \
+        curl \
+        diffutils \
+        findutils \
+        glibc \
+        gnupg \
+        inetutils \
+        keyutils \
+        less \
+        lsof \
+        man-db \
+        man-pages \
+        mesa \
+        mlocate \
+        mtr \
+        ncurses \
+        nss-mdns \
+        opengl-driver \
+        openssh \
+        pigz \
+        pinentry \
+        procps-ng \
+        rsync \
+        shadow \
+        sudo \
+        tcpdump \
+        time \
+        traceroute \
+        tree \
+        tzdata \
+        unzip \
+        util-linux \
+        util-linux-libs \
+        vte-common \
+        vulkan-intel \
+        vulkan-radeon \
+        wget \
+        words \
+        xorg-xauth \
+        zip \
+        --noconfirm && \
+    rm -rf /var/cache/pacman/pkg/*
+
+# Add paru and install AUR packages
+USER build
+WORKDIR /home/build
+RUN git clone https://aur.archlinux.org/paru-bin.git --single-branch && \
+    cd paru-bin && \
+    makepkg -si --noconfirm && \
+    cd .. && \
+    rm -drf paru-bin
+#    paru -S \
+#        aur/placeholder \
+#        --noconfirm
+USER root
+WORKDIR /
+
+# Cleanup
+RUN sed -i 's@#en_US.UTF-8@en_US.UTF-8@g' /etc/locale.gen && \
+    userdel -r build && \
+    rm -drf /home/build && \
+    sed -i '/build ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
+    sed -i '/root ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
+    rm -rf /tmp/*

--- a/toolboxes/arch-toolbox/Containerfile.archamdgpupro
+++ b/toolboxes/arch-toolbox/Containerfile.archamdgpupro
@@ -1,0 +1,36 @@
+FROM ghcr.io/ublue-os/arch-toolbox AS arch-toolbox-amdgpupro
+
+# Install amdgpu-pro, remove other drivers
+RUN useradd -m --shell=/bin/bash build && usermod -L build && \
+    echo "build ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    echo "root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+USER build
+WORKDIR /home/build
+RUN paru -R \
+        libglvnd \
+        vulkan-intel \
+        vulkan-radeon \
+        mesa \
+        --noconfirm && \
+    paru -Syu \
+        amdgpu-pro-oglp \
+        lib32-amdgpu-pro-oglp \
+        vulkan-amdgpu-pro \
+        lib32-vulkan-amdgpu-pro \
+        amf-amdgpu-pro \
+        --noconfirm && \
+    sudo rm -rf /var/cache/pacman/pkg/* && \
+    rm -rf /home/build/.cache/*
+
+USER root
+WORKDIR /
+
+# Cleanup
+RUN userdel -r build && \
+    rm -drf /home/build && \
+    sed -i '/build ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
+    sed -i '/root ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
+    rm -rf \
+        /tmp/* \
+        /var/cache/pacman/pkg/*

--- a/toolboxes/arch-toolbox/Containerfile.archamdgpupro
+++ b/toolboxes/arch-toolbox/Containerfile.archamdgpupro
@@ -1,5 +1,9 @@
 FROM ghcr.io/ublue-os/arch-toolbox AS arch-toolbox-amdgpupro
 
+LABEL com.github.containers.toolbox="true" \
+      usage="This image is meant to be used with the toolbox or distrobox command" \
+      summary="A cloud-native terminal experience powered by Arch Linux with AMDGPU PRO"
+
 # Install amdgpu-pro, remove other drivers
 RUN useradd -m --shell=/bin/bash build && usermod -L build && \
     echo "build ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \


### PR DESCRIPTION
moves https://github.com/ublue-os/arch-distrobox  as per #1 

- ubuntu 24.04 runner, zstd:chunked
- added quadlet files, systemd services and distrobox .ini files
- split the containerfile into 2 files for with and without amdgpupro

I mostly copy and pasted the original workflow and it may still need some work if it is not up to standards or could be simpler. This is my first time playing around with gh actions. So I will probably still need some help with that