### PR TITLE
fix(build): Move misplaced 'extra-args' param.

### DIFF
--- a/.github/workflows/build-blincusui-app.yml
+++ b/.github/workflows/build-blincusui-app.yml
@@ -79,6 +79,9 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
+          extra-args: |
+            --compression-format=zstd:chunked
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
@@ -86,8 +89,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          extra-args: |
-            --compression-format=zstd:chunked
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.8.1

--- a/.github/workflows/build-debian-toolbox.yml
+++ b/.github/workflows/build-debian-toolbox.yml
@@ -80,6 +80,7 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build-incus-app.yml
+++ b/.github/workflows/build-incus-app.yml
@@ -80,6 +80,9 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
+          extra-args: |
+            --compression-format=zstd:chunked
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
@@ -87,8 +90,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          extra-args: |
-            --compression-format=zstd:chunked
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.8.1

--- a/.github/workflows/build-ubuntu-toolbox.yml
+++ b/.github/workflows/build-ubuntu-toolbox.yml
@@ -80,6 +80,9 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
+          extra-args: |
+            --compression-format=zstd:chunked
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
@@ -87,8 +90,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          extra-args: |
-            --compression-format=zstd:chunked
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.8.1

--- a/.github/workflows/build-wolfi-toolbox.yml
+++ b/.github/workflows/build-wolfi-toolbox.yml
@@ -89,6 +89,8 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
+          extra-args: |
+            --compression-format=zstd:chunked
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -97,8 +99,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          extra-args: |
-            --compression-format=zstd:chunked
 
       # Sign container
       - uses: sigstore/cosign-installer@v3.8.1


### PR DESCRIPTION
In some github workflows, the param
```          
          extra-args: |
            --compression-format=zstd:chunked
```
is used with the `docker/login-action` instead with `redhat-actions/push-to-registry`. This raises a warning during build, thou build completes successfully.
