### PR TITLE
fix(wolfi): remove /bin/sh symlink

### DIFF
--- a/toolboxes/wolfi-toolbox/Containerfile.wolfi
+++ b/toolboxes/wolfi-toolbox/Containerfile.wolfi
@@ -59,8 +59,7 @@ RUN git clone https://github.com/89luca89/distrobox.git --single-branch /tmp/dis
     cp /tmp/distrobox/distrobox-init /usr/bin/entrypoint && \
     wget https://github.com/1player/host-spawn/releases/download/$(cat /tmp/distrobox/distrobox-host-exec | grep host_spawn_version= | cut -d "\"" -f 2)/host-spawn-$(uname -m) -O /usr/bin/host-spawn && \
     chmod +x /usr/bin/host-spawn && \
-    rm -drf /tmp/distrobox && \
-    ln -fs /bin/sh /usr/bin/sh
+    rm -drf /tmp/distrobox
 
 # Make some symlinks
 RUN mkdir -p /usr/local/bin  && \


### PR DESCRIPTION
The following [commit](https://github.com/wolfi-dev/os/commit/8534cbcb94b665654df9af10295baf8716b532b2) broke Wolfi builds.

```
STEP 9/12: RUN mkdir -p /usr/local/bin  &&     ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/docker &&     ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/flatpak &&     ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/podman &&     ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/rpm-ostree
error running container: from /usr/bin/crun creating container for [/bin/sh -c mkdir -p /usr/local/bin  &&     ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/docker &&     ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/flatpak &&     ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/podman &&     ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/rpm-ostree]: open executable: Too many levels of symbolic links
```

Removed `ln -fs /bin/sh /usr/bin/sh` and symlinks are now as follows:
```
/bin/sh -> /bin/busybox
/usr/bin/sh -> /bin/busybox
```