### PR TITLE
chore(renovate): fix debian automerge/group rule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,7 @@
       "groupName": "toolbox-images",
       "matchUpdateTypes": ["digest"],
       "matchDepNames": [
-        "docker.io/library/debian:bookworm",
+        "docker.io/library/debian",
         "ghcr.io/ublue-os/fedora-toolbox",
         "ghcr.io/ublue-os/ubuntu-toolbox",
         "ghcr.io/ublue-os/wolfi-toolbox",


### PR DESCRIPTION
Tells Renovate to group the debian update in with the other images.
Also configures auto merging.