### PR TITLE
feat(ubuntu): add fd

### DIFF
--- a/toolboxes/ubuntu-toolbox/packages.ubuntu
+++ b/toolboxes/ubuntu-toolbox/packages.ubuntu
@@ -9,6 +9,7 @@ dialog
 diffutils
 direnv
 dirmngr
+fd-find
 findutils
 fish
 fzf


### PR DESCRIPTION
Would be nice to have that available by default.

I didn't add the `find` alias [found in bluefin-cli](https://github.com/ublue-os/toolboxes/blob/main/toolboxes/bluefin-cli/files/etc/profile.d/modern-unix.sh#L19-L20) since that seems too encroaching.