### PR TITLE
chore(renovate): hardcode schedule with specific times

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,11 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices",
-    "schedule:daily"
+    "config:best-practices"
   ],
 
   "rebaseWhen": "never",
+  "schedule": [
+    "* 0 * * *"
+  ],
 
   "packageRules": [
     {


### PR DESCRIPTION
Now Renovate runs as a GitHub Action, it doesn't seem to keep track of when it was previously ran.
To fix this, we can force the specific times where Renovate is allowed to create PRs.
Renovate doesn't care about minute granularity, so use a wildcard.