### PR TITLE
feat: add script packages to fedora

### DIFF
--- a/toolboxes/fedora-toolbox/packages.fedora
+++ b/toolboxes/fedora-toolbox/packages.fedora
@@ -53,3 +53,4 @@ vulkan
 zsh
 vim
 ripgrep
+script


### PR DESCRIPTION
since f42 (i believe) fedora toolbox stopped to start instantly, after some digging i find that it is caused by `command -v script` failing. The package is probably removed upstream and this pr add it so the toolbox can start instantly again.