### PR TITLE
bump fedora toolbox to f43

### DIFF
--- a/toolboxes/fedora-toolbox/Containerfile.fedora
+++ b/toolboxes/fedora-toolbox/Containerfile.fedora
@@ -33,7 +33,7 @@ RUN dnf install -y \
     "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm" && \
     dnf install -y \
     intel-media-driver \
-    nvidia-vaapi-driver && \
+    libva-nvidia-driver && \
     dnf swap -y mesa-va-drivers mesa-va-drivers-freeworld && \
     dnf swap -y mesa-vdpau-drivers mesa-vdpau-drivers-freeworld && \
     dnf clean all


### PR DESCRIPTION
#521

Problem: `nvidia-vaapi-driver` cant be resolved. Not Yet available for f43?