### PR TITLE
feat: re-enable chunkah for arch images

### DIFF
--- a/.github/workflows/build-arch-toolbox.yml
+++ b/.github/workflows/build-arch-toolbox.yml
@@ -82,6 +82,10 @@ jobs:
           labels: |
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/boxkit/main/README.md
 
+      - name: Compute SOURCE_DATE_EPOCH
+        id: epoch
+        run: echo "epoch=$(date -d '${{ github.event.head_commit.timestamp }}' +%s)" >> $GITHUB_OUTPUT
+
       # Build image using Buildah action
       - name: Build Image
         id: build_image
@@ -96,6 +100,9 @@ jobs:
           oci: false
           extra-args: |
             --target=${{ matrix.base_name }} --security-opt=seccomp=unconfined
+            --skip-unused-stages=false
+          build-args: |
+            SOURCE_DATE_EPOCH=${{ steps.epoch.outputs.epoch }}
 
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12

--- a/.github/workflows/build-steambox.yml
+++ b/.github/workflows/build-steambox.yml
@@ -85,6 +85,10 @@ jobs:
           labels: |
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/boxkit/main/README.md
 
+      - name: Compute SOURCE_DATE_EPOCH
+        id: epoch
+        run: echo "epoch=$(date -d '${{ github.event.head_commit.timestamp }}' +%s)" >> $GITHUB_OUTPUT
+
       # Build image using Buildah action
       - name: Build Image
         id: build_image
@@ -99,6 +103,9 @@ jobs:
           oci: false
           extra-args: |
             --target=${{ matrix.base_name }} --security-opt=seccomp=unconfined
+            --skip-unused-stages=false
+          build-args: |
+            SOURCE_DATE_EPOCH=${{ steps.epoch.outputs.epoch }}
 
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12

--- a/toolboxes/arch-toolbox/Containerfile.arch
+++ b/toolboxes/arch-toolbox/Containerfile.arch
@@ -91,7 +91,9 @@ RUN sed -i 's@#en_US.UTF-8@en_US.UTF-8@g' /etc/locale.gen && \
     rm -drf /home/build && \
     sed -i '/build ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
     sed -i '/root ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
-    rm -rf /tmp/*
+    rm -rf \
+        /tmp/* \
+        /etc/pacman.d/gnupg/S.gpg-agent.extra
 
 # https://github.com/coreos/chunkah
 FROM quay.io/coreos/chunkah:latest AS chunkah

--- a/toolboxes/arch-toolbox/Containerfile.arch
+++ b/toolboxes/arch-toolbox/Containerfile.arch
@@ -93,7 +93,7 @@ RUN sed -i 's@#en_US.UTF-8@en_US.UTF-8@g' /etc/locale.gen && \
     sed -i '/root ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
     rm -rf \
         /tmp/* \
-        /etc/pacman.d/gnupg/S.gpg-agent.extra
+        /etc/pacman.d/gnupg/S.*
 
 # https://github.com/coreos/chunkah
 FROM quay.io/coreos/chunkah:latest AS chunkah

--- a/toolboxes/arch-toolbox/Containerfile.arch
+++ b/toolboxes/arch-toolbox/Containerfile.arch
@@ -94,7 +94,7 @@ RUN sed -i 's@#en_US.UTF-8@en_US.UTF-8@g' /etc/locale.gen && \
     rm -rf /tmp/*
 
 # https://github.com/coreos/chunkah
-FROM quay.io/coreos/chunkah AS chunkah
+FROM quay.io/coreos/chunkah:latest AS chunkah
 
 # Rechunk
 ARG SOURCE_DATE_EPOCH

--- a/toolboxes/arch-toolbox/Containerfile.arch
+++ b/toolboxes/arch-toolbox/Containerfile.arch
@@ -92,8 +92,7 @@ RUN sed -i 's@#en_US.UTF-8@en_US.UTF-8@g' /etc/locale.gen && \
     sed -i '/build ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
     sed -i '/root ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
     rm -rf \
-        /tmp/* \
-        /etc/pacman.d/gnupg/S.*
+        /tmp/*
 
 # https://github.com/coreos/chunkah
 FROM quay.io/coreos/chunkah:latest AS chunkah
@@ -104,6 +103,7 @@ ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 RUN --mount=from=builder,src=/,target=/chunkah,ro \
     --mount=type=bind,target=/run/src,rw \
     chunkah build \
+    --skip-special-files \
     --max-layers 64 \
     --label=com.github.containers.toolbox=true \
     --label=name=arch-toolbox \

--- a/toolboxes/arch-toolbox/Containerfile.arch
+++ b/toolboxes/arch-toolbox/Containerfile.arch
@@ -102,7 +102,6 @@ ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 RUN --mount=from=builder,src=/,target=/chunkah,ro \
     --mount=type=bind,target=/run/src,rw \
     chunkah build \
-    --prune /etc/pacman.d/gnupg/ \
     --max-layers 64 \
     --label=com.github.containers.toolbox=true \
     --label=name=arch-toolbox \

--- a/toolboxes/arch-toolbox/Containerfile.arch
+++ b/toolboxes/arch-toolbox/Containerfile.arch
@@ -1,8 +1,4 @@
-FROM quay.io/toolbx/arch-toolbox@sha256:40a85480d3e8c72d9b2a56f8615b66accae502b9d233b3a18266121656467e5d AS arch-toolbox
-
-LABEL com.github.containers.toolbox="true" \
-      usage="This image is meant to be used with the toolbox or distrobox command" \
-      summary="A cloud-native terminal experience powered by Arch Linux"
+FROM quay.io/toolbx/arch-toolbox@sha256:efe730526c9dbd871eccf6e5ae11997cc6f0c3eac708ec1245e777421b9c79eb AS builder
 
 # Pacman Initialization
 # Create build user
@@ -96,3 +92,23 @@ RUN sed -i 's@#en_US.UTF-8@en_US.UTF-8@g' /etc/locale.gen && \
     sed -i '/build ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
     sed -i '/root ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
     rm -rf /tmp/*
+
+# https://github.com/coreos/chunkah
+FROM quay.io/coreos/chunkah AS chunkah
+
+# Rechunk
+ARG SOURCE_DATE_EPOCH
+ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
+RUN --mount=from=builder,src=/,target=/chunkah,ro \
+    --mount=type=bind,target=/run/src,rw \
+    chunkah build \
+    --prune /etc/pacman.d/gnupg/ \
+    --max-layers 64 \
+    --label=com.github.containers.toolbox=true \
+    --label=name=arch-toolbox \
+    --label=usage="This image is meant to be used with the toolbox or distrobox command" \
+    --label=summary="A cloud-native terminal experience powered by Arch Linux" \
+    > /run/src/out.ociarchive
+
+# Deploy final chunked image
+FROM oci-archive:out.ociarchive AS arch-toolbox

--- a/toolboxes/debian-toolbox/Containerfile.debian
+++ b/toolboxes/debian-toolbox/Containerfile.debian
@@ -36,7 +36,7 @@ RUN --mount=type=cache,dst=/var/cache/apt \
     apt-get remove -y attr
 
 # https://github.com/coreos/chunkah
-FROM quay.io/coreos/chunkah AS chunkah
+FROM quay.io/coreos/chunkah:latest AS chunkah
 
 # Rechunk
 ARG SOURCE_DATE_EPOCH

--- a/toolboxes/fedora-toolbox/Containerfile.fedora
+++ b/toolboxes/fedora-toolbox/Containerfile.fedora
@@ -29,7 +29,7 @@ RUN --mount=type=cache,dst=/var/cache \
     dnf swap -y mesa-vdpau-drivers mesa-vdpau-drivers-freeworld
 
 # https://github.com/coreos/chunkah
-FROM quay.io/coreos/chunkah AS chunkah
+FROM quay.io/coreos/chunkah:latest AS chunkah
 
 # Rechunk
 ARG SOURCE_DATE_EPOCH

--- a/toolboxes/steambox/Containerfile.steambox
+++ b/toolboxes/steambox/Containerfile.steambox
@@ -83,7 +83,7 @@ RUN sed -i 's@ (Runtime)@@g' /usr/share/applications/steam.desktop && \
         /home/build/.cache/*
         /tmp/* \
         /var/cache/pacman/pkg/*
-        /etc/pacman.d/gnupg/S.gpg-agent.extra
+        /etc/pacman.d/gnupg/S.*
 
 # https://github.com/coreos/chunkah
 FROM quay.io/coreos/chunkah:latest AS chunkah
@@ -118,7 +118,7 @@ RUN sed -i 's/-march=native -mtune=native/-march=x86-64 -mtune=generic/g' /etc/m
 RUN sed -i 's/-march=x86-64 -mtune=generic/-march=native -mtune=native/g' /etc/makepkg.conf && \
     rm -rf \
         /tmp/*
-        /etc/pacman.d/gnupg/S.gpg-agent.extra
+        /etc/pacman.d/gnupg/S.*
 
 # https://github.com/coreos/chunkah
 FROM quay.io/coreos/chunkah:latest AS chunkah

--- a/toolboxes/steambox/Containerfile.steambox
+++ b/toolboxes/steambox/Containerfile.steambox
@@ -93,7 +93,6 @@ ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 RUN --mount=from=builder,src=/,target=/chunkah,ro \
     --mount=type=bind,target=/run/src,rw \
     chunkah build \
-    --prune /etc/pacman.d/gnupg/ \
     --max-layers 64 \
     --label=name=steambox \
     > /run/src/out.ociarchive
@@ -128,7 +127,6 @@ ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 RUN --mount=from=builder-gnome,src=/,target=/chunkah,ro \
     --mount=type=bind,target=/run/src,rw \
     chunkah build \
-    --prune /etc/pacman.d/gnupg/ \
     --max-layers 64 \
     --label=name=steambox-gnome \
     > /run/src/out.ociarchive

--- a/toolboxes/steambox/Containerfile.steambox
+++ b/toolboxes/steambox/Containerfile.steambox
@@ -80,10 +80,9 @@ RUN sed -i 's@ (Runtime)@@g' /usr/share/applications/steam.desktop && \
     sed -i '/build ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
     sed -i '/root ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
     rm -rf \
-        /home/build/.cache/*
+        /home/build/.cache/* \
         /tmp/* \
         /var/cache/pacman/pkg/*
-        /etc/pacman.d/gnupg/S.*
 
 # https://github.com/coreos/chunkah
 FROM quay.io/coreos/chunkah:latest AS chunkah
@@ -94,6 +93,7 @@ ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 RUN --mount=from=builder,src=/,target=/chunkah,ro \
     --mount=type=bind,target=/run/src,rw \
     chunkah build \
+    --skip-special-files \
     --max-layers 64 \
     --label=name=steambox \
     > /run/src/out.ociarchive
@@ -118,7 +118,6 @@ RUN sed -i 's/-march=native -mtune=native/-march=x86-64 -mtune=generic/g' /etc/m
 RUN sed -i 's/-march=x86-64 -mtune=generic/-march=native -mtune=native/g' /etc/makepkg.conf && \
     rm -rf \
         /tmp/*
-        /etc/pacman.d/gnupg/S.*
 
 # https://github.com/coreos/chunkah
 FROM quay.io/coreos/chunkah:latest AS chunkah
@@ -129,6 +128,7 @@ ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 RUN --mount=from=builder-gnome,src=/,target=/chunkah,ro \
     --mount=type=bind,target=/run/src,rw \
     chunkah build \
+    --skip-special-files \
     --max-layers 64 \
     --label=name=steambox-gnome \
     > /run/src/out.ociarchive

--- a/toolboxes/steambox/Containerfile.steambox
+++ b/toolboxes/steambox/Containerfile.steambox
@@ -1,4 +1,4 @@
-FROM ghcr.io/ublue-os/arch-toolbox@sha256:bb3729060e7f9762ee47d7fd72d3c31b6a85cf4efe29125f99aadfa503325c4c AS steambox
+FROM ghcr.io/ublue-os/arch-toolbox@sha256:bb3729060e7f9762ee47d7fd72d3c31b6a85cf4efe29125f99aadfa503325c4c AS builder
 
 COPY ./toolboxes/steambox/files /
 
@@ -84,7 +84,24 @@ RUN sed -i 's@ (Runtime)@@g' /usr/share/applications/steam.desktop && \
         /tmp/* \
         /var/cache/pacman/pkg/*
 
-FROM steambox as steambox-gnome
+# https://github.com/coreos/chunkah
+FROM quay.io/coreos/chunkah AS chunkah
+
+# Rechunk
+ARG SOURCE_DATE_EPOCH
+ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
+RUN --mount=from=builder,src=/,target=/chunkah,ro \
+    --mount=type=bind,target=/run/src,rw \
+    chunkah build \
+    --prune /etc/pacman.d/gnupg/ \
+    --max-layers 64 \
+    --label=name=steambox \
+    > /run/src/out.ociarchive
+
+# Deploy final chunked image
+FROM oci-archive:out.ociarchive AS steambox
+
+FROM builder as builder-gnome
 
 # Replace KDE portal with GNOME portal, swap included icon theme.
 RUN sed -i 's/-march=native -mtune=native/-march=x86-64 -mtune=generic/g' /etc/makepkg.conf && \
@@ -101,3 +118,20 @@ RUN sed -i 's/-march=native -mtune=native/-march=x86-64 -mtune=generic/g' /etc/m
 RUN sed -i 's/-march=x86-64 -mtune=generic/-march=native -mtune=native/g' /etc/makepkg.conf && \
     rm -rf \
         /tmp/*
+
+# https://github.com/coreos/chunkah
+FROM quay.io/coreos/chunkah AS chunkah
+
+# Rechunk
+ARG SOURCE_DATE_EPOCH
+ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
+RUN --mount=from=builder-gnome,src=/,target=/chunkah,ro \
+    --mount=type=bind,target=/run/src,rw \
+    chunkah build \
+    --prune /etc/pacman.d/gnupg/ \
+    --max-layers 64 \
+    --label=name=steambox-gnome \
+    > /run/src/out.ociarchive
+
+# Deploy final chunked image
+FROM oci-archive:out.ociarchive AS steambox-gnome

--- a/toolboxes/steambox/Containerfile.steambox
+++ b/toolboxes/steambox/Containerfile.steambox
@@ -79,10 +79,11 @@ RUN sed -i 's@ (Runtime)@@g' /usr/share/applications/steam.desktop && \
     rm -drf /home/build && \
     sed -i '/build ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
     sed -i '/root ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers && \
-    rm -rf /home/build/.cache/* && \
     rm -rf \
+        /home/build/.cache/*
         /tmp/* \
         /var/cache/pacman/pkg/*
+        /etc/pacman.d/gnupg/S.gpg-agent.extra
 
 # https://github.com/coreos/chunkah
 FROM quay.io/coreos/chunkah:latest AS chunkah
@@ -117,6 +118,7 @@ RUN sed -i 's/-march=native -mtune=native/-march=x86-64 -mtune=generic/g' /etc/m
 RUN sed -i 's/-march=x86-64 -mtune=generic/-march=native -mtune=native/g' /etc/makepkg.conf && \
     rm -rf \
         /tmp/*
+        /etc/pacman.d/gnupg/S.gpg-agent.extra
 
 # https://github.com/coreos/chunkah
 FROM quay.io/coreos/chunkah:latest AS chunkah

--- a/toolboxes/steambox/Containerfile.steambox
+++ b/toolboxes/steambox/Containerfile.steambox
@@ -85,7 +85,7 @@ RUN sed -i 's@ (Runtime)@@g' /usr/share/applications/steam.desktop && \
         /var/cache/pacman/pkg/*
 
 # https://github.com/coreos/chunkah
-FROM quay.io/coreos/chunkah AS chunkah
+FROM quay.io/coreos/chunkah:latest AS chunkah
 
 # Rechunk
 ARG SOURCE_DATE_EPOCH
@@ -120,7 +120,7 @@ RUN sed -i 's/-march=x86-64 -mtune=generic/-march=native -mtune=native/g' /etc/m
         /tmp/*
 
 # https://github.com/coreos/chunkah
-FROM quay.io/coreos/chunkah AS chunkah
+FROM quay.io/coreos/chunkah:latest AS chunkah
 
 # Rechunk
 ARG SOURCE_DATE_EPOCH

--- a/toolboxes/ubuntu-toolbox/Containerfile.ubuntu
+++ b/toolboxes/ubuntu-toolbox/Containerfile.ubuntu
@@ -39,7 +39,7 @@ RUN --mount=type=cache,dst=/var/cache/apt \
     apt-get remove -y attr
 
 # https://github.com/coreos/chunkah
-FROM quay.io/coreos/chunkah AS chunkah
+FROM quay.io/coreos/chunkah:latest AS chunkah
 
 # Rechunk
 ARG SOURCE_DATE_EPOCH


### PR DESCRIPTION
Assigning `user.component` on Arch is no longer required, as of 0.4.0 update chunkah now supports ALPM/pacman package databases just like how it does with RPM. https://github.com/coreos/chunkah/releases/tag/v0.4.0

Instead of pruning GNUPG directory completely, `--skip-special-files` was added to simply exclude socket files