### PR TITLE
chore(renovate): disable patch for debian and major for fedora

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,16 @@
       "matchFileNames": [".github/workflows/**.yaml", ".github/workflows/**.yml"],
     },
     {
+      "enabled": false,
+      "matchUpdateTypes": ["patch"],
+      "matchDepNames": ["docker.io/library/debian"]
+    },
+    {
+      "enabled": false,
+      "matchUpdateTypes": ["major"],
+      "matchDepNames": ["registry.fedoraproject.org/fedora-toolbox"]
+    },
+    {
       "automerge": true,
       "groupName": "toolbox-images",
       "matchUpdateTypes": ["digest"],


### PR DESCRIPTION
Disabling a few minor annoyances for Debian (#620, #669) and Fedora (#554). I assume that's how it should be handled