### PR TITLE
chore(fedora): change uri to quay.io

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,7 +28,7 @@
     {
       "enabled": false,
       "matchUpdateTypes": ["major"],
-      "matchDepNames": ["registry.fedoraproject.org/fedora-toolbox"]
+      "matchDepNames": ["quay.io/fedora/fedora-toolbox"]
     },
     {
       "automerge": true,
@@ -43,7 +43,7 @@
         "ghcr.io/ublue-os/wolfi-toolbox",
         "ghcr.io/ublue-os/arch-toolbox",
         "quay.io/toolbx/arch-toolbox",
-        "registry.fedoraproject.org/fedora-toolbox"
+        "quay.io/fedora/fedora-toolbox"
       ]
     }
   ]

--- a/toolboxes/fedora-toolbox/Containerfile.fedora
+++ b/toolboxes/fedora-toolbox/Containerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-toolbox:44@sha256:54eaef913a35b69070005ef12d0a2dbfe35bfd27c2594e3eafde0d48ecd33b8d AS builder
+FROM quay.io/fedora/fedora-toolbox:44@sha256:96961ae552aea383c59fad8b660394fb963607acbae843443f4e1dafffa3555f AS builder
 COPY ./toolboxes/fedora-toolbox/packages.fedora /toolbox-packages
 
 # Set up dependencies


### PR DESCRIPTION
Reading through https://forge.fedoraproject.org/infra/tickets/issues/11543 it looks like Fedora wants to move all of containers out of registry.fedoraproject.org to quay.io, but it is unclear when it will happen exactly, at least for toolbox image. Since registry.fedoraproject.org/fedora-toolbox and quay.io/fedora/fedora-toolbox shares the same content it can be safely changed as it was already suggested in linked issue