### PR TITLE
fix(fedora): swap to ogc mesa from terra

### DIFF
--- a/toolboxes/fedora-toolbox/Containerfile.fedora
+++ b/toolboxes/fedora-toolbox/Containerfile.fedora
@@ -6,6 +6,9 @@ RUN --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \
     --mount=type=tmpfs,dst=/tmp \
     dnf upgrade -y && \
+    dnf install -y --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release-mesa && \
+    dnf -y config-manager setopt "*fedora*".exclude="mesa-*" && \
+    dnf distro-sync -y --repo='terra-mesa' mesa-filesystem && \
     dnf install -y \
         $(cat toolbox-packages | xargs) && \
     rm /toolbox-packages && \
@@ -17,15 +20,14 @@ RUN --mount=type=cache,dst=/var/cache \
     dnf install -y 'dnf-command(copr)' && \
     dnf copr enable -y kylegospo/distrobox-utils && \
     dnf install -y \
-    xdg-utils-distrobox && \
+        xdg-utils-distrobox && \
     ln -s /usr/bin/distrobox-host-exec /usr/bin/flatpak && \
     dnf install -y \
         "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" \
         "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm" && \
     dnf install -y \
         intel-media-driver \
-        libva-nvidia-driver \
-        mesa-va-drivers-freeworld
+        libva-nvidia-driver
 
 # https://github.com/coreos/chunkah
 FROM quay.io/coreos/chunkah:latest AS chunkah


### PR DESCRIPTION
I started noticing a weird error in GitHub Actions logs when trying to install `mesa-va-drivers-freeworld` specifically which uses 26.0.7 Fedora repos doesn't have yet: https://github.com/ublue-os/toolboxes/actions/runs/26432121723/job/77807274317#step:6:385

<details>
<summary>Not to mention already deployed containers...</summary>

<img width="951" height="512" alt="dms-screenshot-1779697202306" src="https://github.com/user-attachments/assets/56538bfd-3bd7-4323-ab11-a99025366617" />

</details>

So instead of dealing with this DNF started to downgrade Mesa to 26.0.3 which is worse given recent security vulnerabilities to a few utilities. This PR swaps Mesa to more updated and enhanced one from OGC in Terra repos which is the same Mesa used in Bazzite and other OGC-powered distros. Only terra-mesa repo gets added to the image. Removing `-freeworld` package is required and is mentioned in Terra docs (https://docs.terrapkg.com/usage/installing/#mesa).

How to mitigate the issue: https://github.com/ublue-os/toolboxes/issues/689#issuecomment-4551769907

RPM Fusion is still used for `intel-media-driver` package.